### PR TITLE
Introduce a no-op package manager

### DIFF
--- a/pkg/packages/noop.go
+++ b/pkg/packages/noop.go
@@ -1,0 +1,27 @@
+package packages
+
+import (
+	"fmt"
+)
+
+// NoopPackageManager implements a no-op of the PackageManager interface.
+// Its purpose is to enable scenarios where no package handling is required,
+// i.e. the necessary executables are already available on the host.
+type NoopPackageManager struct{}
+
+func (p *NoopPackageManager) Setup() error {
+	return nil
+}
+
+func (p *NoopPackageManager) Install(pkg, version string) (error, bool) {
+	return nil, true
+}
+
+func (p *NoopPackageManager) Unitfile(pkg string) (string, error) {
+	// This is fine as pod creation will synthesize a unit file.
+	return "", fmt.Errorf("noop")
+}
+
+func (p *NoopPackageManager) Clean(pkg string) string {
+	return pkg
+}

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -55,6 +55,8 @@ func New(cfg provider.InitConfig) (*P, error) {
 
 	case "arch":
 		p.pkg = new(packages.ArchlinuxPackageManager)
+	case "noop":
+		p.pkg = new(packages.NoopPackageManager)
 	}
 
 	p.rm = cfg.ResourceManager


### PR DESCRIPTION
Thank you for this project, @miekg!

I'm hereby proposing a no-op package manager for scenarios where package management isn't necessary.

For instance, this would make sense in distros that aim for immutability and (may) have all the binaries that one requires available already.

I understand if this doesn't fit the project's goals and am fine if this is rejected with little to no explanation.