### PR TITLE
node: fix known labels

### DIFF
--- a/systemd/node.go
+++ b/systemd/node.go
@@ -10,6 +10,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const(
+	defaultOS="Linux"
+)
+
 // ConfigureNode enables a provider to configure the node object that will be used for Kubernetes.
 func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.Status.Capacity = p.capacity()
@@ -17,7 +21,7 @@ func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.Status.Conditions = p.nodeConditions()
 	node.Status.Addresses = p.nodeAddresses()
 	node.Status.DaemonEndpoints = p.nodeDaemonEndpoints()
-	node.Status.NodeInfo.OperatingSystem = "Linux"
+	node.Status.NodeInfo.OperatingSystem = defaultOS
 	node.Status.NodeInfo.KernelVersion = system.Kernel()
 	node.Status.NodeInfo.OSImage = system.Image()
 	node.Status.NodeInfo.ContainerRuntimeVersion = system.Version()
@@ -25,7 +29,7 @@ func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 		Name: system.Hostname(),
 		Labels: map[string]string{
 			"type":                              "virtual-kubelet",
-			"kubernetes.io/role":                "agent",
+			"kubernetes.io/os":                  defaultOS,
 			"kubernetes.io/hostname":            system.Hostname(),
 			corev1.LabelZoneFailureDomainStable: "localhost",
 			corev1.LabelZoneRegionStable:        system.Hostname(),


### PR DESCRIPTION
First, this addresses a problem where [_nodes are not allowed to set their role_](https://github.com/kubernetes/kubernetes/issues/84912#issuecomment-551362981). I don't know how you got this working because it doesn't work for me: get a 403 Forbidden when registering the node. Maybe it's the k3s thing that's more permissive?

Then, we set the known label `kubernetes.io/os` to `Linux`, which is what workloads usually refer to (`PodSpec.nodeSelector`) to ensure they're not placed on nodes running other OSes, ie Windows.