### PR TITLE
Make ExecStart empty

### DIFF
--- a/systemd/pod.go
+++ b/systemd/pod.go
@@ -189,7 +189,9 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		uf = uf.Overwrite("Service", "RemainAfterExit", "true")
 
 		execStart := commandAndArgs(uf, c)
-		uf = uf.Overwrite("Service", "ExecStart", strings.Join(execStart, " "))
+		if len(execStart) > 0 {
+			uf = uf.Overwrite("Service", "ExecStart", strings.Join(execStart, " "))
+		}
 
 		id := string(pod.ObjectMeta.UID) // give multiple containers the same access? Need to test this.
 		uf = uf.Insert(kubernetesSection, "Namespace", pod.ObjectMeta.Namespace)

--- a/systemd/provider_test.go
+++ b/systemd/provider_test.go
@@ -57,7 +57,6 @@ func testPodSpecUnit(t *testing.T, p *P, base string) {
 		t.Errorf("failed to call CreatePod: %v", err)
 		return
 	}
-	// now it's just string compare
 	got := ""
 	for _, c := range pod.Spec.Containers {
 		name := PodToUnitName(pod, c.Name)

--- a/systemd/testdata/provider/prometheus.units
+++ b/systemd/testdata/provider/prometheus.units
@@ -15,7 +15,7 @@ StandardError=journal
 User=0
 Group=0
 RemainAfterExit=true
-ExecStart=need "--config.file=/etc/prometheus/prometheus.yml" "--storage.tsdb.path=/tmp/prometheus"
+ExecStart= "--config.file=/etc/prometheus/prometheus.yml" "--storage.tsdb.path=/tmp/prometheus"
 TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444

--- a/systemd/testdata/provider/uptimed.units
+++ b/systemd/testdata/provider/uptimed.units
@@ -15,7 +15,7 @@ StandardError=journal
 User=1
 Group=1
 RemainAfterExit=true
-ExecStart=need to be overwritten
+ExecStart=
 TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444

--- a/systemd/unit.go
+++ b/systemd/unit.go
@@ -278,7 +278,7 @@ Description=systemk
 Documentation=man:systemk(8)
 
 [Service]
-ExecStart=need to be overwritten
+ExecStart=
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
When synthesizing a unit make the execstart empty, doing so uncovered a
couple of crashes, fix them too and make things more robust.

Fixes: #20