### PR TITLE
export node's IP addresses as env vars

### DIFF
--- a/k3s/prometheus.yaml
+++ b/k3s/prometheus.yaml
@@ -54,11 +54,19 @@ spec:
     windowsOptions:
       runAsUserName: "prometheus"
   serviceAccountName: prometheus
+  initContainers:
+  - name: init-prometheus-config
+    image: bash
+    command: ["bash", "-c"]
+    args: ["envsubst '$SYSTEMK_NODE_INTERNAL_IP' < /tmp/init-prometheus/prometheus.yaml.orig > /tmp/init-prometheus/prometheus.yaml"]
+    volumeMounts:
+    - name: prometheus-config-volume
+      mountPath: /tmp/init-prometheus
   containers:
   - name: prometheus
     image: deb://www.miek.nl/prometheus_2.23.0-0~20.040_amd64.deb
     args:
-    - "--config.file=/etc/prometheus/prometheus.yml"
+    - "--config.file=/etc/prometheus/prometheus.yaml"
     - "--storage.tsdb.path=/tmp/prometheus"
     ports:
     - containerPort: 9090
@@ -82,7 +90,7 @@ metadata:
   name: prometheus-server-conf
   namespace: monitoring
 data:
-  prometheus.yml: |-
+  prometheus.yaml.orig: |-
     scrape_configs:
     - job_name: 'kubernetes-pods'
       kubernetes_sd_configs:
@@ -97,4 +105,11 @@ data:
       - source_labels: [__meta_kubernetes_pod_name]
         action: replace
         target_label: kubernetes_pod_name
----
+      - source_labels: [__address__]
+        regex: '.*:(\d+)'
+        action: replace
+        target_label: __address__
+        replacement: '${SYSTEMK_NODE_INTERNAL_IP}:$1'
+      - source_labels: [__meta_kubernetes_pod_container_init]
+        regex: 'true'
+        action: drop

--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -198,7 +198,7 @@ func (m *UnitManager) States(prefix string) (map[string]*unit.State, error) {
 	if err != nil {
 		return nil, err
 	}
-	klog.Infof("%d statusses for prefix %q returned", len(dbusStatuses), prefix)
+	klog.Infof("%d statuses returned", len(dbusStatuses))
 
 	states := make(map[string]*unit.State)
 	for _, dus := range dbusStatuses {

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -14,7 +14,6 @@ import (
 var (
 	// this is a variable so it can be overridden during unit-testing.
 	osReleaseFilePath = "/etc/os-release"
-
 )
 
 // Memory returns the amount of memory in the system.

--- a/systemd/env.go
+++ b/systemd/env.go
@@ -2,6 +2,8 @@ package systemd
 
 import (
 	"fmt"
+	"net"
+	"net/url"
 
 	"github.com/virtual-kubelet/systemk/pkg/system"
 )
@@ -10,8 +12,28 @@ import (
 // It returns a list of strings VAR=VALUE.
 func (p *P) defaultEnvironment() []string {
 	env := []string{}
+
+	host := "127.0.0.1"
+	port := "6444"
+	if p.Host != "" {
+		url, _ := url.Parse(p.Host)
+		host, port, _ = net.SplitHostPort(url.Host)
+	}
+
 	env = append(env, fmt.Sprintf("HOSTNAME=%s", system.Hostname()))
-	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_PORT=%d", 6444))        // get from provider/flag?
-	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_HOST=%s", "127.0.0.1")) // get from provider/flag?
+	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_PORT=%s", port))
+	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_HOST=%s", host))
+
+	// These are systemk spefific environment variables. TODO(miek): should this be done at all?
+	// SYSTEMK_NODE_INTERNAL_IP: internal address of the node
+	// SYSTEMK_NODE_EXTERNAL_IP: external address of the node
+	env = append(env, mkEnvVar("NODE_INTERNAL_IP", p.NodeInternalIP.Address))
+	env = append(env, mkEnvVar("NODE_EXTERNAL_IP", p.NodeExternalIP.Address))
+
 	return env
+}
+
+func mkEnvVar(name, value string) string {
+	const s = "SYSTEMK_"
+	return s + name + "=" + value
 }

--- a/systemd/env_test.go
+++ b/systemd/env_test.go
@@ -1,0 +1,28 @@
+package systemd
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestProviderIPEnvironment(t *testing.T) {
+	p := new(P)
+	p.NodeInternalIP = &corev1.NodeAddress{Address: "192.168.1.1", Type: corev1.NodeInternalIP}
+	p.NodeExternalIP = &corev1.NodeAddress{Address: "172.16.0.1", Type: corev1.NodeExternalIP}
+
+	env := p.defaultEnvironment()
+	found := 0
+	for _, e := range env {
+		println(e)
+		if e == "SYSTEMK_NODE_INTERNAL_IP=192.168.1.1" {
+			found++
+		}
+		if e == "SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1" {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Errorf("failed to find SYSTEMK_NODE_INTERNAL_IP or SYSTEMK_NODE_EXTERNAL_IP")
+	}
+}

--- a/systemd/provider_test.go
+++ b/systemd/provider_test.go
@@ -25,6 +25,8 @@ func TestProviderPodSpecUnits(t *testing.T) {
 	p := new(P)
 	p.m, _ = manager.NewTest()
 	p.pkg = &packages.NoopPackageManager{}
+	p.NodeInternalIP = &corev1.NodeAddress{Address: "192.168.1.1", Type: corev1.NodeInternalIP}
+	p.NodeExternalIP = &corev1.NodeAddress{Address: "172.16.0.1", Type: corev1.NodeExternalIP}
 
 	os.Setenv("HOSTNAME", "localhost")
 

--- a/systemd/testdata/provider/prometheus.units
+++ b/systemd/testdata/provider/prometheus.units
@@ -20,6 +20,8 @@ TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444
 Environment=KUBERNETES_SERVICE_HOST=127.0.0.1
+Environment=SYSTEMK_NODE_INTERNAL_IP=192.168.1.1
+Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 
 [X-Kubernetes]
 Namespace=default

--- a/systemd/testdata/provider/uptimed.units
+++ b/systemd/testdata/provider/uptimed.units
@@ -20,6 +20,8 @@ TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444
 Environment=KUBERNETES_SERVICE_HOST=127.0.0.1
+Environment=SYSTEMK_NODE_INTERNAL_IP=192.168.1.1
+Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 
 [X-Kubernetes]
 Namespace=default
@@ -47,6 +49,8 @@ TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444
 Environment=KUBERNETES_SERVICE_HOST=127.0.0.1
+Environment=SYSTEMK_NODE_INTERNAL_IP=192.168.1.1
+Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 
 [X-Kubernetes]
 Namespace=default

--- a/systemd/unit.go
+++ b/systemd/unit.go
@@ -96,8 +96,8 @@ func (p *P) statsToPod(stats map[string]*unit.State) *corev1.Pod {
 
 			Message:   string(toPhase(containerStatuses)),
 			Reason:    "",
-			HostIP:    (externalOrInternalAddress(p.Addresses)).Address,
-			PodIP:     (externalOrInternalAddress(p.Addresses)).Address,
+			HostIP:    p.NodeExternalIP.Address,
+			PodIP:     p.NodeExternalIP.Address,
 			StartTime: &starttime,
 		},
 	}


### PR DESCRIPTION
This uncovered a heap of stuff that wasn't done properly, hence the size
of the PR.

This adds 2 new flags --node-ip and --node-external-ip, which override
whatever we find ourselves. We also set this on node object. And we
export these as SYSTEMK_NODE_INTERNAL_IP and SYSTEMK_NODE_EXTERNAL_IP
(unclear if we keep this though, looks handy though). Next I want to
test this setup with Prometheus rewriting targets based on these values.
The step after that is using CoreDNS which binds the metrics to the
internal IP address by using the SYSTEMK_NODE_INTERNAL_IP env var.

Signed-off-by: Miek Gieben <miek@miek.nl>
