### PR TITLE
feature: clean-up volumes on Pod deletion

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,7 +60,7 @@ func main() {
 	o.Version = strings.Join([]string{k8sVersion, "vk-systemd", buildVersion}, "-")
 	o.NodeName = system.Hostname()
 	o.EnableNodeLease = true
-	
+
 	node, err := cli.New(ctx,
 		cli.WithBaseOpts(o),
 		cli.WithPersistentFlags(flags),

--- a/main.go
+++ b/main.go
@@ -59,6 +59,8 @@ func main() {
 	o.Provider = "systemd"
 	o.Version = strings.Join([]string{k8sVersion, "vk-systemd", buildVersion}, "-")
 	o.NodeName = system.Hostname()
+	o.EnableNodeLease = true
+	
 	node, err := cli.New(ctx,
 		cli.WithBaseOpts(o),
 		cli.WithPersistentFlags(flags),

--- a/systemd/env.go
+++ b/systemd/env.go
@@ -15,8 +15,8 @@ func (p *P) defaultEnvironment() []string {
 
 	host := "127.0.0.1"
 	port := "6444"
-	if p.Host != "" {
-		url, _ := url.Parse(p.Host)
+	if p.kubernetesURL != "" {
+		url, _ := url.Parse(p.kubernetesURL)
 		host, port, _ = net.SplitHostPort(url.Host)
 	}
 

--- a/systemd/node.go
+++ b/systemd/node.go
@@ -20,7 +20,7 @@ func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.Status.Allocatable = capacity()
 	node.Status.Conditions = nodeConditions()
 	node.Status.Addresses = append([]corev1.NodeAddress{*p.NodeInternalIP}, *p.NodeExternalIP)
-	node.Status.DaemonEndpoints = nodeDaemonEndpoints(p.DaemonPort)
+	node.Status.DaemonEndpoints = nodeDaemonEndpoints(p.daemonPort)
 	node.Status.NodeInfo.OperatingSystem = defaultOS
 	node.Status.NodeInfo.KernelVersion = system.Kernel()
 	node.Status.NodeInfo.OSImage = system.Image()

--- a/systemd/pod.go
+++ b/systemd/pod.go
@@ -84,7 +84,7 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		for _, v := range c.VolumeMounts {
 			dir, ok := vol[v.Name]
 			if !ok {
-				klog.Infof("failed to find volumeMount %s in the specific volumes, skpping", v.Name)
+				klog.Infof("failed to find volumeMount %s in the specific volumes, skipping", v.Name)
 				continue
 			}
 
@@ -136,7 +136,7 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 			}
 		}
 
-		// TODO(): parse c.Image for tag to get version. Check ImagePullAways to reinstall??
+		// TODO(): parse c.Image for tag to get version. Check ImagePullAlways to reinstall??
 		// if we're downloading the image, the image name needs cleaning
 		installed, err := p.pkg.Install(c.Image, "")
 		if err != nil {
@@ -186,7 +186,7 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 			}
 		}
 
-		// keep the unit around, the control plane where clear it with a DeletePod.
+		// keep the unit around, until DeletePod is triggered.
 		// this is also for us to return the state even after the unit left the stage.
 		uf = uf.Overwrite("Service", "RemainAfterExit", "true")
 
@@ -290,7 +290,7 @@ func (p *P) DeletePod(ctx context.Context, pod *corev1.Pod) error {
 	for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
 		name := PodToUnitName(pod, c.Name)
 		if err := p.m.TriggerStop(name); err != nil {
-			klog.Warningf("Failed to triggger top: %s", err)
+			klog.Warningf("Failed to trigger top: %s", err)
 		}
 		if err := p.m.Unload(name); err != nil {
 			klog.Warningf("Failed to unload: %s", err)

--- a/systemd/pod.go
+++ b/systemd/pod.go
@@ -22,7 +22,7 @@ import (
 
 func (p *P) GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
 	klog.Info("GetPod called")
-	stats, err := p.m.States(UnitPrefix(namespace, name))
+	stats, err := p.m.States(unitPrefix(namespace, name))
 	if err != nil {
 		klog.Infof("Failed to get states: %s", err)
 		return nil, nil
@@ -32,7 +32,7 @@ func (p *P) GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, er
 }
 
 func (p *P) GetPods(ctx context.Context) ([]*corev1.Pod, error) {
-	states, err := p.m.States(Prefix)
+	states, err := p.m.States(prefix)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +144,7 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 			return err
 		}
 		c.Image = p.pkg.Clean(c.Image) // clean up the image if fetched with https
-		name := PodToUnitName(pod, c.Name)
+		name := podToUnitName(pod, c.Name)
 		if installed {
 			p.m.Mask(c.Image + unit.ServiceSuffix)
 		}
@@ -270,7 +270,7 @@ func (p *P) GetPodStatus(ctx context.Context, namespace, name string) (*corev1.P
 func (p *P) GetContainerLogs(ctx context.Context, namespace, podName, containerName string, opts api.ContainerLogOpts) (io.ReadCloser, error) {
 	klog.Infof("GetContainerLogs called")
 
-	unitname := UnitPrefix(namespace, podName) + separator + containerName
+	unitname := unitPrefix(namespace, podName) + separator + containerName
 	args := []string{"-u", unitname}
 	cmd := exec.Command("journalctl", args...)
 	// returns the buffers? What about following, use pipes here or something?
@@ -288,7 +288,7 @@ func (p *P) UpdatePod(ctx context.Context, pod *corev1.Pod) error {
 func (p *P) DeletePod(ctx context.Context, pod *corev1.Pod) error {
 	klog.Infof("DeletePod called")
 	for _, c := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
-		name := PodToUnitName(pod, c.Name)
+		name := podToUnitName(pod, c.Name)
 		if err := p.m.TriggerStop(name); err != nil {
 			klog.Warningf("Failed to trigger top: %s", err)
 		}
@@ -311,12 +311,12 @@ func (p *P) UpdateSecret(ctx context.Context, pod *corev1.Pod, s *corev1.Secret)
 	return err
 }
 
-func PodToUnitName(pod *corev1.Pod, containerName string) string {
-	return UnitPrefix(pod.Namespace, pod.Name) + separator + containerName + unit.ServiceSuffix
+func podToUnitName(pod *corev1.Pod, containerName string) string {
+	return unitPrefix(pod.Namespace, pod.Name) + separator + containerName + unit.ServiceSuffix
 }
 
-func UnitPrefix(namespace, podName string) string {
-	return Prefix + separator + namespace + separator + podName
+func unitPrefix(namespace, podName string) string {
+	return prefix + separator + namespace + separator + podName
 }
 
 func Image(name string) string {
@@ -352,8 +352,8 @@ func Namespace(name string) string {
 }
 
 const (
-	// Prefix the unit file prefix we used.
-	Prefix    = "systemk"
+	// prefix the unit file prefix we used.
+	prefix    = "systemk"
 	separator = "."
 )
 

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -27,10 +27,10 @@ type P struct {
 
 	NodeInternalIP *corev1.NodeAddress
 	NodeExternalIP *corev1.NodeAddress
-	DaemonPort     int32
+	ClusterDomain  string
 
-	ClusterDomain string
-	Host          string
+	daemonPort    int32
+	kubernetesURL string
 }
 
 // New returns a new systemd provider.
@@ -66,8 +66,8 @@ func New(cfg provider.InitConfig) (*P, error) {
 	}
 
 	p.rm = cfg.ResourceManager
-	p.DaemonPort = cfg.DaemonPort
 	p.ClusterDomain = cfg.KubeClusterDomain
+	p.daemonPort = cfg.DaemonPort
 
 	if cfg.ConfigPath == "" {
 		return p, nil
@@ -80,8 +80,7 @@ func New(cfg provider.InitConfig) (*P, error) {
 	if err != nil {
 		return p, err
 	}
-
-	p.Host = restConfig.Host
+	p.kubernetesURL = restConfig.Host
 
 	clientset, err := nodeutil.ClientsetFromEnv(cfg.ConfigPath)
 	if err != nil {

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -70,7 +70,6 @@ func New(cfg provider.InitConfig) (*P, error) {
 		p.pkg = new(packages.NoopPackageManager)
 	}
 
-	p.rm = cfg.ResourceManager
 	p.ClusterDomain = cfg.KubeClusterDomain
 	p.daemonPort = cfg.DaemonPort
 

--- a/systemd/provider_test.go
+++ b/systemd/provider_test.go
@@ -61,7 +61,7 @@ func testPodSpecUnit(t *testing.T, p *P, base string) {
 	}
 	got := ""
 	for _, c := range pod.Spec.Containers {
-		name := PodToUnitName(pod, c.Name)
+		name := podToUnitName(pod, c.Name)
 		got += p.m.Unit(name)
 	}
 

--- a/systemd/unit.go
+++ b/systemd/unit.go
@@ -23,7 +23,7 @@ func (p *P) statsToPod(stats map[string]*unit.State) *corev1.Pod {
 		return nil
 	}
 	name := ""
-	// Pick a random unit, the things we care about should be identical btween them.
+	// Pick a random unit, the things we care about should be identical between them.
 	// We might need to pick the "correct" one at some point.
 	for k := range stats {
 		name = k

--- a/systemd/volumes.go
+++ b/systemd/volumes.go
@@ -30,7 +30,7 @@ const (
 	volumeSecret
 )
 
-// volumes inspects the volumes and returns a mapping with the volume's Name and the directory on-disk that
+// volumes inspects the PodSpec.Volumes attribute and returns a mapping with the volume's Name and the directory on-disk that
 // should be used for this. The on-disk structure is prepared and can be used.
 // which considered what volumes should be setup. Defaults to volumeAll
 func (p *P) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
@@ -208,3 +208,8 @@ func chown(name, uid, gid string) error {
 }
 
 const dirPerms = 02750
+
+func cleanPodEphemeralVolumes(podId string) error {
+	podEphemeralVolumes := filepath.Join(varrun, podId)
+	return os.RemoveAll(podEphemeralVolumes)
+}

--- a/systemd/volumes.go
+++ b/systemd/volumes.go
@@ -30,7 +30,7 @@ const (
 	volumeSecret
 )
 
-// volumes inspecs the volumes and returns a maaping with the volume's Name and the directory on-disk that
+// volumes inspects the volumes and returns a mapping with the volume's Name and the directory on-disk that
 // should be used for this. The on-disk structure is prepared and can be used.
 // which considered what volumes should be setup. Defaults to volumeAll
 func (p *P) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {


### PR DESCRIPTION
Since each Pod has its own root path for the volumes systemk manages, ie `/var/run/<pod uuid>`, we can simply remove said path.

I also include a couple minor changs.