### PR TITLE
Add --dir -d flag to force mounts points be below a path

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,11 @@ The primary group will be found by systemk and both a `User` and `Group` will be
 unit file. The files created on disk for the configMap/secrets/emptyDir will be made of the same
 user/group.
 
+### Restricting mount points
+
+You can restrict the allowed mounts points for the pod's volumes. By default mounts under "/var" are
+allowed, but this can be changed via the `--dir` or `-d` flag.
+
 ### Limitations
 
 By using systemd and the hosts network we have weak isolation between pods, i.e. no more than

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.15
 require (
 	github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883
 	github.com/coreos/go-systemd/v22 v22.1.0
+	github.com/go-logr/logr v0.2.0
 	github.com/gorilla/mux v1.7.3
 	github.com/spf13/pflag v1.0.5
 	github.com/virtual-kubelet/node-cli v0.3.1

--- a/main.go
+++ b/main.go
@@ -77,7 +77,7 @@ func main() {
 			p.SetNodeIPs(nodeIP, nodeEIP)
 			klog.Infof("Using internal/external IP addresses: %s/%s", p.NodeInternalIP.Address, p.NodeExternalIP.Address)
 
-			p.topdirs = topdirs
+			p.Topdirs = topdirs
 			if certFile == "" || keyFile == "" {
 				klog.Info("No certificates found, disabling GetContainerLogs")
 				return p, nil

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ func main() {
 		keyFile  string
 		nodeIP   string
 		nodeEIP  string
+		topdirs  []string
 	)
 	flags := pflag.NewFlagSet("client", pflag.ContinueOnError)
 	// these options need to be make inline with k3s or make clear they afffect logs, certfile and keyfile is too short
@@ -49,6 +50,7 @@ func main() {
 	flags.StringVar(&keyFile, "keyfile", "", "keyfile")
 	flags.StringVarP(&nodeIP, "node-ip", "i", "", "IP address to advertise for node")
 	flags.StringVar(&nodeEIP, "node-external-ip", "", "External IP address to advertise for node")
+	flags.StringSliceVarP(&topdirs, "dir", "d", []string{"/var"}, "Only allow mounts below these directories")
 
 	ctx := cli.ContextWithCancelOnSignal(context.Background())
 
@@ -75,6 +77,7 @@ func main() {
 			p.SetNodeIPs(nodeIP, nodeEIP)
 			klog.Infof("Using internal/external IP addresses: %s/%s", p.NodeInternalIP.Address, p.NodeExternalIP.Address)
 
+			p.topdirs = topdirs
 			if certFile == "" || keyFile == "" {
 				klog.Info("No certificates found, disabling GetContainerLogs")
 				return p, nil

--- a/systemd/env_test.go
+++ b/systemd/env_test.go
@@ -14,7 +14,6 @@ func TestProviderIPEnvironment(t *testing.T) {
 	env := p.defaultEnvironment()
 	found := 0
 	for _, e := range env {
-		println(e)
 		if e == "SYSTEMK_NODE_INTERNAL_IP=192.168.1.1" {
 			found++
 		}

--- a/systemd/noop_logger.go
+++ b/systemd/noop_logger.go
@@ -1,0 +1,13 @@
+package systemd
+
+import "github.com/go-logr/logr"
+
+// noopLogger disables klogs, this is useful in tests.
+type noopLogger struct{}
+
+func (e *noopLogger) Enabled() bool                                             { return false }
+func (e *noopLogger) Info(msg string, keysAndValues ...interface{})             {}
+func (e *noopLogger) Error(err error, msg string, keysAndValues ...interface{}) {}
+func (e *noopLogger) V(level int) logr.Logger                                   { return e }
+func (e *noopLogger) WithValues(keysAndValues ...interface{}) logr.Logger       { return e }
+func (e *noopLogger) WithName(name string) logr.Logger                          { return e }

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -33,10 +33,10 @@ type P struct {
 	NodeInternalIP *corev1.NodeAddress
 	NodeExternalIP *corev1.NodeAddress
 	ClusterDomain  string
+	Topdirs        []string
 
 	daemonPort    int32
 	kubernetesURL string
-	topdirs       []string
 }
 
 // New returns a new systemd provider.

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -36,6 +36,7 @@ type P struct {
 
 	daemonPort    int32
 	kubernetesURL string
+	topdirs       []string
 }
 
 // New returns a new systemd provider.

--- a/systemd/provider_test.go
+++ b/systemd/provider_test.go
@@ -12,12 +12,14 @@ import (
 	"github.com/virtual-kubelet/systemk/pkg/manager"
 	"github.com/virtual-kubelet/systemk/pkg/packages"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/klog/v2"
 	"k8s.io/kubectl/pkg/scheme"
 )
 
 const dir = "testdata/provider"
 
 func TestProviderPodSpecUnits(t *testing.T) {
+	klog.SetLogger(&noopLogger{})
 	testFiles, err := ioutil.ReadDir(dir)
 	if err != nil {
 		t.Fatalf("could not read %s: %q", dir, err)

--- a/systemd/volumes.go
+++ b/systemd/volumes.go
@@ -55,7 +55,7 @@ func (p *P) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 			}
 			dir := filepath.Join(varrun, id)
 			dir = filepath.Join(dir, emptyDir)
-			if err := isBelow(p.topdirs, dir); err != nil {
+			if err := isBelow(p.Topdirs, dir); err != nil {
 				return nil, err
 			}
 			if err := mkdirAllChown(dir, dirPerms, uid, gid); err != nil {
@@ -82,7 +82,7 @@ func (p *P) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 
 			dir := filepath.Join(varrun, id)
 			dir = filepath.Join(dir, secretDir)
-			if err := isBelow(p.topdirs, dir); err != nil {
+			if err := isBelow(p.Topdirs, dir); err != nil {
 				return nil, err
 			}
 			if err := mkdirAllChown(dir, dirPerms, uid, gid); err != nil {
@@ -124,7 +124,7 @@ func (p *P) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 
 			dir := filepath.Join(varrun, id)
 			dir = filepath.Join(dir, configmapDir)
-			if err := isBelow(p.topdirs, dir); err != nil {
+			if err := isBelow(p.Topdirs, dir); err != nil {
 				return nil, err
 			}
 			if err := mkdirAllChown(dir, dirPerms, uid, gid); err != nil {

--- a/systemd/volumes_test.go
+++ b/systemd/volumes_test.go
@@ -23,3 +23,35 @@ func TestMkdirAll(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestIsBelowPath(t *testing.T) {
+	tests := []struct {
+		top   string
+		path  string
+		below bool
+	}{
+		{"/", "/tmp/x", true},
+		{"/", "/", false},
+		{"/tmp", "/", false},
+		{"/tmp/x", "/", false},
+	}
+	for i, tc := range tests {
+		ok := isBelowPath(tc.top, tc.path)
+		if ok != tc.below {
+			t.Errorf("test %d, expected %t, got %t", i, tc.below, ok)
+		}
+	}
+}
+func TestIsBelow(t *testing.T) {
+	if err := isBelow([]string{"/var", "/tmp"}, "/tmp/x"); err != nil {
+		t.Errorf("/tmp/x should be below /tmp")
+	}
+
+	if err := isBelow([]string{"/var", "/tmp"}, "/"); err == nil {
+		t.Errorf("/ should not be below /tmp or /var")
+	}
+
+	if err := isBelow([]string{"/var", "/tmp"}, "/var"); err == nil {
+		t.Errorf("/var should not be below /tmp or /var")
+	}
+}


### PR DESCRIPTION
This adds extra security to force mountspoints to be below a specified
path list (defaults to "/var"), as to prevent system modifications.

This is also showed HostPaths don't work, but appeared to work because
everything was done as root.

Also remove stray println in tests and cleanup the test output (disable
logging)

Signed-off-by: Miek Gieben <miek@miek.nl>
