### PR TITLE
pod: don't process volumes if package fails to install

### DIFF
--- a/systemd/pod.go
+++ b/systemd/pod.go
@@ -79,6 +79,14 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		isInit := i < len(pod.Spec.InitContainers)
 		klog.Infof("Processing container %d (init=%t)", i, isInit)
 
+		// TODO(): parse c.Image for tag to get version. Check ImagePullAlways to reinstall??
+		// if we're downloading the image, the image name needs cleaning
+		installed, err := p.pkg.Install(c.Image, "")
+		if err != nil {
+			klog.Infof("Failed to install package %q: %s", c.Image, err)
+			return err
+		}
+
 		bindmounts := []string{}
 		bindmountsro := []string{}
 		rwpaths := []string{}
@@ -136,13 +144,6 @@ func (p *P) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 			}
 		}
 
-		// TODO(): parse c.Image for tag to get version. Check ImagePullAlways to reinstall??
-		// if we're downloading the image, the image name needs cleaning
-		installed, err := p.pkg.Install(c.Image, "")
-		if err != nil {
-			klog.Infof("Failed to install package %q: %s", c.Image, err)
-			return err
-		}
 		c.Image = p.pkg.Clean(c.Image) // clean up the image if fetched with https
 		name := podToUnitName(pod, c.Name)
 		if installed {


### PR DESCRIPTION
Found this when a Pod that isn't supported by `systemk` got scheduled onto it..

```
I0110 23:52:07.354344    2619 pod.go:65] CreatedPod called
I0110 23:52:07.354576    2619 volumes.go:41] Looking at volume "kube-proxy"#0
I0110 23:52:07.354876    2619 volumes.go:125] Created "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0" for configmap: kube-proxy
I0110 23:52:07.355169    2619 volumes.go:177] Chowning "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.808583862.tmp" to .
I0110 23:52:07.355409    2619 volumes.go:186] Writing data "apiVersion" to path "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.808583862.tmp"
I0110 23:52:07.355696    2619 volumes.go:191] Renaming /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.808583862.tmp to /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/config.conf
I0110 23:52:07.356037    2619 volumes.go:177] Chowning "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.668754077.tmp" to .
I0110 23:52:07.356275    2619 volumes.go:186] Writing data "apiVersion" to path "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.668754077.tmp"
I0110 23:52:07.356553    2619 volumes.go:191] Renaming /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/systemk.668754077.tmp to /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/configmaps/#0/kubeconfig.conf
I0110 23:52:07.356777    2619 volumes.go:41] Looking at volume "xtables-lock"#1
I0110 23:52:07.357059    2619 volumes.go:41] Looking at volume "lib-modules"#2
I0110 23:52:07.357268    2619 volumes.go:41] Looking at volume "kube-proxy-token-xd46g"#3
I0110 23:52:07.357444    2619 volumes.go:86] Created "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3" for secret: kube-proxy-token-xd46g
I0110 23:52:07.357718    2619 volumes.go:177] Chowning "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.155047256.tmp" to .
I0110 23:52:07.357959    2619 volumes.go:186] Writing data "eyJhbGciOi" to path "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.155047256.tmp"
I0110 23:52:07.358232    2619 volumes.go:191] Renaming /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.155047256.tmp to /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/token
I0110 23:52:07.358491    2619 volumes.go:177] Chowning "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.131882199.tmp" to .
I0110 23:52:07.358722    2619 volumes.go:186] Writing data "-----BEGIN" to path "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.131882199.tmp"
I0110 23:52:07.359004    2619 volumes.go:191] Renaming /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.131882199.tmp to /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/ca.crt
I0110 23:52:07.359227    2619 volumes.go:177] Chowning "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.157728842.tmp" to .
I0110 23:52:07.359440    2619 volumes.go:186] Writing data "kube-syste" to path "/var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.157728842.tmp"
I0110 23:52:07.359653    2619 volumes.go:191] Renaming /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/systemk.157728842.tmp to /var/run/6a30ca6e-2f9b-49a4-940e-5cb26e020eae/secrets/#3/namespace
I0110 23:52:07.359882    2619 pod.go:79] Processing container 0 (init=false)
I0110 23:52:07.360239    2619 pod.go:131] Chowning "/var/lib/kube-proxy"
I0110 23:52:07.360504    2619 debian.go:30] Checking if "k8s.gcr.io/kube-proxy:v1.18.14" is installed
I0110 23:52:07.369489    2619 debian.go:65] Running /usr/bin/apt-get -qq --assume-yes --no-install-recommends install k8s.gcr.io/kube-proxy:v1.18.14
I0110 23:52:07.442281    2619 pod.go:142] Failed to install package "k8s.gcr.io/kube-proxy:v1.18.14": failed to install: exit status 100
E: Unable to locate package k8s.gcr.io
E: Couldn't find any package by glob 'k8s.gcr.io'
E: Couldn't find any package by regex 'k8s.gcr.io'
```

We could come up with improved ways to deal with this but in the current state I believe this is enough.