### PR TITLE
cli: respect flag --nodename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@
 
 # binaries and other artifacts
 systemk
+systemk.*
 vendor

--- a/main.go
+++ b/main.go
@@ -61,15 +61,15 @@ func main() {
 	o.Provider = "systemd"
 	o.Version = strings.Join([]string{k8sVersion, "vk-systemd", buildVersion}, "-")
 
-	// Enforce usage of Node Leases.
-	o.EnableNodeLease = true
-
 	node, err := cli.New(ctx,
 		cli.WithBaseOpts(o),
 		cli.WithPersistentFlags(flags),
-		// Register hostname flag default value callback.
+		// Validate configuration after flag parsing.
 		cli.WithPersistentPreRunCallback(func() error {
-			// Ensure o.NodeName is set.
+			// Enforce usage of Node Leases API.
+			o.EnableNodeLease = true
+
+			// Ensure Node name is set.
 			//
 			// Setting the Node name is computed in the following order:
 			// 1. flag --nodename, or if not set

--- a/main.go
+++ b/main.go
@@ -61,6 +61,7 @@ func main() {
 	o.Provider = "systemd"
 	o.Version = strings.Join([]string{k8sVersion, "vk-systemd", buildVersion}, "-")
 
+	// Enforce usage of Node Leases.
 	o.EnableNodeLease = true
 
 	node, err := cli.New(ctx,

--- a/pkg/system/system.go
+++ b/pkg/system/system.go
@@ -45,14 +45,7 @@ func CPU() string {
 }
 
 // Hostname returns the machine's host name.
-// if the environment variable HOSTNAME is present this takes precedence.
-// if the environment variabe HOSTNAME is present this takes precedence.
 func Hostname() string {
-	// there is also a flag for this to systemk ? use that instead?
-	if h := os.Getenv("HOSTNAME"); h != "" {
-		return h
-	}
-
 	h, _ := os.Hostname()
 	return h
 }

--- a/systemd/env.go
+++ b/systemd/env.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-
-	"github.com/virtual-kubelet/systemk/pkg/system"
 )
 
 // defaultEnvironment returns the environment that the kubelet uses.
@@ -20,11 +18,11 @@ func (p *P) defaultEnvironment() []string {
 		host, port, _ = net.SplitHostPort(url.Host)
 	}
 
-	env = append(env, fmt.Sprintf("HOSTNAME=%s", system.Hostname()))
+	env = append(env, fmt.Sprintf("HOSTNAME=%s", p.nodename))
 	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_PORT=%s", port))
 	env = append(env, fmt.Sprintf("KUBERNETES_SERVICE_HOST=%s", host))
 
-	// These are systemk spefific environment variables. TODO(miek): should this be done at all?
+	// These are systemk specific environment variables. TODO(miek): should this be done at all?
 	// SYSTEMK_NODE_INTERNAL_IP: internal address of the node
 	// SYSTEMK_NODE_EXTERNAL_IP: external address of the node
 	env = append(env, mkEnvVar("NODE_INTERNAL_IP", p.NodeInternalIP.Address))

--- a/systemd/node.go
+++ b/systemd/node.go
@@ -26,13 +26,13 @@ func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.Status.NodeInfo.OSImage = system.Image()
 	node.Status.NodeInfo.ContainerRuntimeVersion = system.Version()
 	node.ObjectMeta = metav1.ObjectMeta{
-		Name: system.Hostname(),
+		Name: p.nodename,
 		Labels: map[string]string{
 			"type":                              "virtual-kubelet",
 			"kubernetes.io/os":                  defaultOS,
-			"kubernetes.io/hostname":            system.Hostname(),
+			"kubernetes.io/hostname":            p.nodename,
 			corev1.LabelZoneFailureDomainStable: "localhost",
-			corev1.LabelZoneRegionStable:        system.Hostname(),
+			corev1.LabelZoneRegionStable:        p.nodename,
 		},
 	}
 }

--- a/systemd/node.go
+++ b/systemd/node.go
@@ -28,7 +28,7 @@ func (p *P) ConfigureNode(ctx context.Context, node *corev1.Node) {
 	node.ObjectMeta = metav1.ObjectMeta{
 		Name: p.nodename,
 		Labels: map[string]string{
-			"type":                              "virtual-kubelet",
+			"node.kubernetes.io/instance-type":  "systemk",
 			"kubernetes.io/os":                  defaultOS,
 			"kubernetes.io/hostname":            p.nodename,
 			corev1.LabelZoneFailureDomainStable: "localhost",

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -34,6 +34,7 @@ type P struct {
 	NodeExternalIP *corev1.NodeAddress
 	ClusterDomain  string
 
+	nodename      string
 	daemonPort    int32
 	kubernetesURL string
 }
@@ -71,6 +72,7 @@ func New(cfg provider.InitConfig) (*P, error) {
 	}
 
 	p.ClusterDomain = cfg.KubeClusterDomain
+	p.nodename = cfg.NodeName
 	p.daemonPort = cfg.DaemonPort
 
 	// Parse the kubeconfig, yet again, to gain access to the Host field,

--- a/systemd/provider_test.go
+++ b/systemd/provider_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -27,8 +26,7 @@ func TestProviderPodSpecUnits(t *testing.T) {
 	p.pkg = &packages.NoopPackageManager{}
 	p.NodeInternalIP = &corev1.NodeAddress{Address: "192.168.1.1", Type: corev1.NodeInternalIP}
 	p.NodeExternalIP = &corev1.NodeAddress{Address: "172.16.0.1", Type: corev1.NodeExternalIP}
-
-	os.Setenv("HOSTNAME", "localhost")
+	p.nodename = "localhost"
 
 	for _, f := range testFiles {
 		if f.IsDir() {

--- a/systemd/unit.go
+++ b/systemd/unit.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/virtual-kubelet/systemk/pkg/system"
 	"github.com/virtual-kubelet/systemk/pkg/unit"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -66,7 +65,7 @@ func (p *P) statsToPod(stats map[string]*unit.State) *corev1.Pod {
 		},
 		ObjectMeta: om,
 		Spec: corev1.PodSpec{
-			NodeName:       system.Hostname(),
+			NodeName:       p.nodename,
 			Volumes:        []corev1.Volume{},
 			Containers:     containers,
 			InitContainers: initContainers,


### PR DESCRIPTION
Fixes #6

Also, as agreed over Slack, I'm enforcing Node Leases API to be used.

Oh, I've added some instructions for people who want to test against different local Kubernetes solutions, most notably `kind` and `minikube`. This will be truly useful when implementing e2e tests, like we did for VK, which also uses `minikube`.