### PR TITLE
main: allow --node-ip and --node-external-ip to have 0.0.0.0 value

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,8 +50,8 @@ func main() {
 	// these options need to be make inline with k3s or make clear they afffect logs, certfile and keyfile is too short
 	flags.StringVar(&certFile, "certfile", "", "certfile")
 	flags.StringVar(&keyFile, "keyfile", "", "keyfile")
-	flags.StringVarP(&nodeIP, "node-ip", "i", "", "IP address to advertise for node")
-	flags.StringVar(&nodeEIP, "node-external-ip", "", "External IP address to advertise for node")
+	flags.StringVarP(&nodeIP, "node-ip", "i", "", "IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
+	flags.StringVar(&nodeEIP, "node-external-ip", "", "External IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
 	flags.StringSliceVarP(&topdirs, "dir", "d", []string{"/var"}, "Only allow mounts below these directories")
 
 	ctx := cli.ContextWithCancelOnSignal(context.Background())

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -123,6 +123,13 @@ func New(ctx context.Context, cfg provider.InitConfig) (*P, error) {
 }
 
 func (p *P) SetNodeIPs(nodeIP, nodeEIP string) {
+	if nodeIP == "0.0.0.0" {
+		nodeIP = ""
+	}
+	if nodeEIP == "0.0.0.0" {
+		nodeEIP = ""
+	}
+
 	// Get the addresses.
 	internal, external := nodeAddresses()
 	if nodeIP != "" {


### PR DESCRIPTION
This is handy to specify a systemk.service file which uses these
defaults *and* allows them to be overriden

~~~
Environment="NODE_IP=0.0.0.0"
Environment="NODE_EXTERNAL_IP=0.0.0.0"
EnvironmentFile=/etc/default/systemk
~~~
Default is autodetect unless /etc/default/systemk overrides it, this
means the unit file is static and doesn't need to be changed.

Signed-off-by: Miek Gieben <miek@miek.nl>
