### PR TITLE
user systemd support

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,11 +163,13 @@ things:
 1. Packages can't be installed, so you'll need to use a path as the image name (See "Binary Exists in
    File System").
 2. A user systemd must be running with the same uid as systemk.
-3. Systemk must be started with the right set of capabilties:
+3. Systemk must be started with the right set of capabilities:
    `% sudo capsh --caps="cap_chown,cap_setuid,cap_setgid+ep" --user=$UID -- -c "$PWD/systemk -u --kubeconfig $CONFIG"`
    Or an equivalent systemd unit file.
    Note when running a graphical session in Linux you probably have a user systemd already running,
    connecting to that instance requires `cap_sys_admin` to be set as well.
+
+Note: this support is experimental and we may removed it if it turns to be too cumbersome.
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ things:
    Note when running a graphical session in Linux you probably have a user systemd already running,
    connecting to that instance requires `cap_sys_admin` to be set as well.
 
-Note: this support is experimental and we may removed it if it turns to be too cumbersome.
+**Note:** this feature is experimental and we may remove it if it turns to be too cumbersome.
 
 ### Limitations
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ user/group.
 You can restrict the allowed mounts points for the pod's volumes. By default mounts under "/var" are
 allowed, but this can be changed via the `--dir` or `-d` flag.
 
+### Running Without Root Permissions
+
+Some work has been done to be able to run `systemk` without root permissions. This means a couple of
+things:
+
+1. Packages can't be installed, so you'll need to use a path as the image name (See "Binary Exists in
+   File System").
+2. A user systemd must be running with the same uid as systemk.
+3. Systemk must be started with the right set of capabilties:
+   `% sudo capsh --caps="cap_chown,cap_setuid,cap_setgid+ep" --user=$UID -- -c "$PWD/systemk -u --kubeconfig $CONFIG"`
+   Or an equivalent systemd unit file.
+   Note when running a graphical session in Linux you probably have a user systemd already running,
+   connecting to that instance requires `cap_sys_admin` to be set as well.
+
 ### Limitations
 
 By using systemd and the host's network stack we have weak isolation between pods, i.e. no more

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 		nodeIP   string
 		nodeEIP  string
 		topdirs  []string
+		user     bool
 	)
 
 	flags := pflag.NewFlagSet("client", pflag.ContinueOnError)
@@ -52,6 +53,7 @@ func main() {
 	flags.StringVar(&keyFile, "keyfile", "", "keyfile")
 	flags.StringVarP(&nodeIP, "node-ip", "i", "", "IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
 	flags.StringVar(&nodeEIP, "node-external-ip", "", "External IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
+	flags.BoolVarP(&user, "user", "u", false, fmt.Sprintf("Connect to the user's (%q) systemd", os.Getenv("LOGNAME")))
 	flags.StringSliceVarP(&topdirs, "dir", "d", []string{"/var"}, "Only allow mounts below these directories")
 
 	ctx := cli.ContextWithCancelOnSignal(context.Background())
@@ -81,7 +83,7 @@ func main() {
 		cli.WithKubernetesNodeVersion(k8sVersion),
 		cli.WithProvider("systemd", func(cfg provider.InitConfig) (provider.Provider, error) {
 			cfg.ConfigPath = o.KubeConfigPath
-			p, err := systemd.New(ctx, cfg)
+			p, err := systemd.New(ctx, user, cfg)
 			if err != nil {
 				return p, err
 			}

--- a/main.go
+++ b/main.go
@@ -82,8 +82,15 @@ func main() {
 		cli.WithCLIVersion(buildVersion, buildTime),
 		cli.WithKubernetesNodeVersion(k8sVersion),
 		cli.WithProvider("systemd", func(cfg provider.InitConfig) (provider.Provider, error) {
-			cfg.ConfigPath = o.KubeConfigPath
-			p, err := systemd.New(ctx, user, cfg)
+			initCfg := systemd.InitConfig{InitConfig: cfg}
+			initCfg.ConfigPath = o.KubeConfigPath
+			initCfg.SystemdUser = user
+			initCfg.UnitDir = "/var/run/systemk"
+			if user {
+				uid := os.Geteuid()
+				initCfg.UnitDir = fmt.Sprintf("/var/run/user/%d/systemk", uid)
+			}
+			p, err := systemd.New(ctx, initCfg)
 			if err != nil {
 				return p, err
 			}

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	flags.StringVar(&keyFile, "keyfile", "", "keyfile")
 	flags.StringVarP(&nodeIP, "node-ip", "i", "", "IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
 	flags.StringVar(&nodeEIP, "node-external-ip", "", "External IP address to advertise for node, '0.0.0.0' or not provided to auto-detect")
-	flags.BoolVarP(&user, "user", "u", false, fmt.Sprintf("Connect to the user's (%q) systemd", os.Getenv("LOGNAME")))
+	flags.BoolVarP(&user, "user", "u", false, "Connect to the systemd of the user running systemk")
 	flags.StringSliceVarP(&topdirs, "dir", "d", []string{"/var"}, "Only allow mounts below these directories")
 
 	ctx := cli.ContextWithCancelOnSignal(context.Background())

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -18,9 +18,6 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// unitDir is where systemk stores the modified unit files.
-var unitDir = "/var/run/systemk"
-
 // P is a systemd provider.
 type P struct {
 	m   manager.Manager
@@ -41,15 +38,19 @@ type P struct {
 	kubernetesURL string
 }
 
-// Ensure P implements updater at compile time.
-var _ updater = (*P)(nil)
+// InitConfig holds configuration used to initialize the provider.
+type InitConfig struct {
+	provider.InitConfig
+	SystemdUser bool
+	UnitDir     string
+}
 
 // New returns a new systemd provider.
-func New(ctx context.Context, systemdUser bool, cfg provider.InitConfig) (*P, error) {
-	if err := os.MkdirAll(unitDir, 0750); err != nil {
+func New(ctx context.Context, cfg InitConfig) (*P, error) {
+	if err := os.MkdirAll(cfg.UnitDir, 0750); err != nil {
 		return nil, err
 	}
-	m, err := manager.New(unitDir, systemdUser)
+	m, err := manager.New(cfg.UnitDir, cfg.SystemdUser)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +84,7 @@ func New(ctx context.Context, systemdUser bool, cfg provider.InitConfig) (*P, er
 	p.ClusterDomain = cfg.KubeClusterDomain
 	p.nodename = cfg.NodeName
 	p.daemonPort = cfg.DaemonPort
-	p.systemdUser = systemdUser
+	p.systemdUser = cfg.SystemdUser
 
 	// Parse the kubeconfig, yet again, to gain access to the Host field,
 	// which has the value to set for the KUBERNETES_SERVICE_* Pod env vars.
@@ -156,3 +157,6 @@ func (p *P) SetNodeIPs(nodeIP, nodeEIP string) {
 }
 
 var _ provider.Provider = new(P)
+
+// Ensure P implements updater at compile time.
+var _ updater = (*P)(nil)

--- a/systemd/provider.go
+++ b/systemd/provider.go
@@ -34,6 +34,7 @@ type P struct {
 	NodeExternalIP *corev1.NodeAddress
 	ClusterDomain  string
 	Topdirs        []string
+	systemdUser    bool // When true we're connecting to a user's systemd.
 
 	nodename      string
 	daemonPort    int32
@@ -44,11 +45,11 @@ type P struct {
 var _ updater = (*P)(nil)
 
 // New returns a new systemd provider.
-func New(ctx context.Context, cfg provider.InitConfig) (*P, error) {
+func New(ctx context.Context, systemdUser bool, cfg provider.InitConfig) (*P, error) {
 	if err := os.MkdirAll(unitDir, 0750); err != nil {
 		return nil, err
 	}
-	m, err := manager.New(unitDir, false)
+	m, err := manager.New(unitDir, systemdUser)
 	if err != nil {
 		return nil, err
 	}
@@ -82,6 +83,7 @@ func New(ctx context.Context, cfg provider.InitConfig) (*P, error) {
 	p.ClusterDomain = cfg.KubeClusterDomain
 	p.nodename = cfg.NodeName
 	p.daemonPort = cfg.DaemonPort
+	p.systemdUser = systemdUser
 
 	// Parse the kubeconfig, yet again, to gain access to the Host field,
 	// which has the value to set for the KUBERNETES_SERVICE_* Pod env vars.

--- a/systemd/unit_test.go
+++ b/systemd/unit_test.go
@@ -25,7 +25,7 @@ func TestNewUnit(t *testing.T) {
 	}
 	defer os.RemoveAll(dir) // clean up
 	unitDir = dir
-	p, err := New(context.TODO(), provider.InitConfig{})
+	p, err := New(context.TODO(), false, provider.InitConfig{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/systemd/unit_test.go
+++ b/systemd/unit_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/virtual-kubelet/node-cli/provider"
 	"github.com/virtual-kubelet/systemk/pkg/system"
 	"github.com/virtual-kubelet/systemk/pkg/unit"
 )
@@ -24,8 +23,8 @@ func TestNewUnit(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(dir) // clean up
-	unitDir = dir
-	p, err := New(context.TODO(), false, provider.InitConfig{})
+	initCfg := InitConfig{UnitDir: dir}
+	p, err := New(context.TODO(), initCfg)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Connect to a user's systemd instead of the system wide one when the -u
flag is given. This also means that (probably?) the User and Group
settings in the unit file should be removed, because we can't become
another user in a user process.

Signed-off-by: Miek Gieben <miek@miek.nl>
