### PR TITLE
node: container runtime feeds from systemctl

### DIFF
--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -82,7 +82,7 @@ func Image() string {
 
 // Version returns the version of systemd.
 func Version() string {
-	cmd := exec.Command("systemd", "--version")
+	cmd := exec.Command("systemctl", "--version")
 	buf, err := cmd.Output()
 	if err != nil {
 		return ""


### PR DESCRIPTION
`systemd --version` doesn't work on RHEL7 systems.

This change works on Ubuntu 20.04 so I take this change as safe.

```
System Info:
  Machine ID:
  System UUID:
  Boot ID:
  Kernel Version:             5.4.0-60-generic
  OS Image:                   Ubuntu 20.04.1 LTS
  Operating System:           Linux
  Architecture:               amd64
  Container Runtime Version:  systemd 245 (245.4-4ubuntu3.3)
  Kubelet Version:            v1.18.15
  Kube-Proxy Version:
```