### PR TITLE
node: retrieve logs from journal socket

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,6 +17,10 @@ jobs:
     - name: Check out code
       uses: actions/checkout@v2
 
+    - name: Install systemd lib dependencies
+      run: |
+        sudo apt update
+        sudo apt install libsystemd-dev
     - name: Get dependencies
       run: |
         go get golang.org/x/lint/golint

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/virtual-kubelet/systemk/internal/provider"
-	"github.com/virtual-kubelet/virtual-kubelet/node/api"
+	nodeapi "github.com/virtual-kubelet/virtual-kubelet/node/api"
 )
 
 // AcceptedCiphers is the list of accepted TLS ciphers, with known weak ciphers elided
@@ -57,7 +57,7 @@ func loadTLSConfig(certPath, keyPath string) (*tls.Config, error) {
 }
 
 // setupKubeletServer configures and brings up the kubelet API server.
-func setupKubeletServer(ctx context.Context, config *provider.Opts, p provider.Provider, getPodsFromKubernetes api.PodListerFunc) (_ func(), retErr error) {
+func setupKubeletServer(ctx context.Context, config *provider.Opts, p provider.Provider, getPodsFromKubernetes nodeapi.PodListerFunc) (_ func(), retErr error) {
 	var closers []io.Closer
 	cancel := func() {
 		for _, c := range closers {
@@ -88,7 +88,7 @@ func setupKubeletServer(ctx context.Context, config *provider.Opts, p provider.P
 
 		// Setup path routing.
 		mux := http.NewServeMux()
-		podRoutes := api.PodHandlerConfig{
+		podRoutes := nodeapi.PodHandlerConfig{
 			RunInContainer:        p.RunInContainer,
 			GetContainerLogs:      p.GetContainerLogs,
 			GetPodsFromKubernetes: getPodsFromKubernetes,
@@ -96,7 +96,7 @@ func setupKubeletServer(ctx context.Context, config *provider.Opts, p provider.P
 			StreamIdleTimeout:     config.StreamIdleTimeout,
 			StreamCreationTimeout: config.StreamCreationTimeout,
 		}
-		api.AttachPodRoutes(podRoutes, mux, true)
+		nodeapi.AttachPodRoutes(podRoutes, mux, true)
 
 		// Start the server.
 		s := &http.Server{

--- a/internal/testdata/provider/hello.units
+++ b/internal/testdata/provider/hello.units
@@ -13,7 +13,7 @@ ReadOnlyPaths=/
 StandardOutput=journal
 StandardError=journal
 RemainAfterExit=true
-ExecStart=/bin/bash -c "while true; do echo hello; sleep 1; done"
+ExecStart=/bin/bash -c "while true; do date; sleep 5; done"
 TemporaryFileSystem=/var /run
 Environment=HOSTNAME=localhost
 Environment=KUBERNETES_SERVICE_PORT=6444

--- a/internal/testdata/provider/hello.yaml
+++ b/internal/testdata/provider/hello.yaml
@@ -14,4 +14,4 @@ spec:
     - name: bash
       image: /bin/bash
       command: ["/bin/bash", "-c"]
-      args: ["while true; do echo hello; sleep 1; done"]
+      args: ["while true; do date; sleep 5; done"]


### PR DESCRIPTION
... instead of doing it through journalctl CLI.

This is the first step to address #5. What's missing and will eventually be addressed in separate PRs?
- follow mode support
- retrieving logs pertaining to the current Pod, in case a homonym Pod once existed for which journald still has entries for.

Some examples of a Pod named `hello`, that simply prints `date`, every 5 seconds:

`kubectl logs --since`:

```
$ k logs --since 20s hello
Thu Jan 21 23:20:52 WET 2021
Thu Jan 21 23:20:57 WET 2021
Thu Jan 21 23:21:02 WET 2021
Thu Jan 21 23:21:07 WET 2021

$k logs --since 1m hello
Thu Jan 21 23:20:17 WET 2021
Thu Jan 21 23:20:22 WET 2021
Thu Jan 21 23:20:27 WET 2021
Thu Jan 21 23:20:32 WET 2021
Thu Jan 21 23:20:37 WET 2021
Thu Jan 21 23:20:42 WET 2021
Thu Jan 21 23:20:47 WET 2021
Thu Jan 21 23:20:52 WET 2021
Thu Jan 21 23:20:57 WET 2021
Thu Jan 21 23:21:02 WET 2021
Thu Jan 21 23:21:07 WET 2021
Thu Jan 21 23:21:12 WET 2021
```

`kubectl logs --timestamps` - by default, `kubectl` has timestamps disabled:

```
$ k logs --since 20s --timestamps hello
2021-01-21 23:21:02.231042 +0000 WET Thu Jan 21 23:21:02 WET 2021
2021-01-21 23:21:07.23385 +0000 WET Thu Jan 21 23:21:07 WET 2021
2021-01-21 23:21:12.236292 +0000 WET Thu Jan 21 23:21:12 WET 2021
2021-01-21 23:21:17.238822 +0000 WET Thu Jan 21 23:21:17 WET 2021
```

`kubectl logs --tail`:

```
k logs --tail 10 hello
Thu Jan 21 23:22:07 WET 2021
Thu Jan 21 23:22:12 WET 2021
Thu Jan 21 23:22:17 WET 2021
Thu Jan 21 23:22:22 WET 2021
Thu Jan 21 23:22:27 WET 2021
Thu Jan 21 23:22:32 WET 2021
Thu Jan 21 23:22:37 WET 2021
Fri Jan 22 09:07:06 WET 2021
Fri Jan 22 09:07:11 WET 2021
Fri Jan 22 09:07:16 WET 2021

$ k logs --tail 2 hello
Fri Jan 22 09:07:21 WET 2021
Fri Jan 22 09:07:26 WET 2021
```