### PR TITLE
node: machine ID is set in Node info

### DIFF
--- a/internal/provider/node.go
+++ b/internal/provider/node.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/coreos/go-systemd/v22/util"
 	"github.com/virtual-kubelet/systemk/internal/system"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
@@ -26,6 +27,8 @@ func (p *p) ConfigureNode(ctx context.Context, opts *Opts) (*v1.Node, error) {
 		// TODO(pires) wrap the error in a new more meaningful error.
 		return nil, err
 	}
+
+	machineID, _ := util.GetMachineID()
 
 	return &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
@@ -58,6 +61,7 @@ func (p *p) ConfigureNode(ctx context.Context, opts *Opts) (*v1.Node, error) {
 				ContainerRuntimeVersion: system.Version(),
 				KernelVersion:           system.Kernel(),
 				KubeletVersion:          opts.Version,
+				MachineID:               machineID,
 				OperatingSystem:         DefaultOperatingSystem,
 				OSImage:                 system.Image(),
 			},

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -86,7 +86,8 @@ func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceMan
 		podResourceManager: podWatcher,
 	}
 
-	switch system.ID() {
+	systemID := system.ID()
+	switch systemID {
 	case "debian", "ubuntu":
 		p.pkgManager = new(ospkg.DebianManager)
 
@@ -106,7 +107,7 @@ func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceMan
 	case "arch":
 		p.pkgManager = new(ospkg.ArchLinuxManager)
 	default:
-		log.Warn("failed to detect package manager, no-op enabledw which allows to run binaries already available on the host")
+		log.Warnf("found unsupported package manager in %q, limiting systemk to running existing binaries", systemID)
 		p.pkgManager = new(ospkg.NoopManager)
 	}
 


### PR DESCRIPTION
```
System Info:
  Machine ID:                 065b96dc0f1f4f668a4d2f5f8418ae42
  System UUID:
  Boot ID:
  Kernel Version:             5.4.0-62-generic
  OS Image:                   Ubuntu 20.04.1 LTS
  Operating System:           Linux
  Architecture:               amd64
  Container Runtime Version:  systemd 245 (245.4-4ubuntu3.4)
  Kubelet Version:            v1.18.15
```

Also, fixed a typo with a more meaningful message when an unsupported OS package management is found.