### PR TITLE
Use Container instead of Image

### DIFF
--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -406,32 +406,37 @@ func unitPrefix(namespace, podName string) string {
 	return prefix + separator + namespace + separator + podName
 }
 
-func Image(name string) string {
-	el := strings.Split(name, separator) // assume well formed
-	if len(el) < 4 {
-		return ""
-	}
-	return el[3]
-}
-
+// Name returns <namespace>.<podname> from a well formed name.
+// Units are named as 'systemk.<namespace>.<podname>.<image> .
 func Name(name string) string {
-	el := strings.Split(name, separator) // assume well formed
+	el := strings.Split(name, separator)
 	if len(el) < 4 {
 		return ""
 	}
 	return el[1] + separator + el[2]
 }
 
+// Image returns the <image> from the well formed name. See Name.
+func Image(name string) string {
+	el := strings.Split(name, separator)
+	if len(el) < 4 {
+		return ""
+	}
+	return el[3]
+}
+
+// Pod returns <podname> from the well formed name. See Name.
 func Pod(name string) string {
-	el := strings.Split(name, separator) // assume well formed
+	el := strings.Split(name, separator)
 	if len(el) < 4 {
 		return ""
 	}
 	return el[2]
 }
 
+// Namespace returns <namespace> from the well formed name. See Name.
 func Namespace(name string) string {
-	el := strings.Split(name, separator) // assume well formed
+	el := strings.Split(name, separator)
 	if len(el) < 4 {
 		return ""
 	}

--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -211,6 +211,7 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		uf = uf.Insert(kubernetesSection, "Namespace", pod.ObjectMeta.Namespace)
 		uf = uf.Insert(kubernetesSection, "ClusterName", pod.ObjectMeta.ClusterName)
 		uf = uf.Insert(kubernetesSection, "Id", id)
+		uf = uf.Insert(kubernetesSection, "Image", c.Image) // save (cleaned) image name here, we're not tracking this in the unit's name.
 
 		tmpfs := strings.Join(tmp, " ")
 		uf = uf.Insert("Service", "TemporaryFileSystem", tmpfs)
@@ -407,7 +408,7 @@ func unitPrefix(namespace, podName string) string {
 }
 
 // Name returns <namespace>.<podname> from a well formed name.
-// Units are named as 'systemk.<namespace>.<podname>.<image> .
+// Units are named as 'systemk.<namespace>.<podname>.<container>'.
 func Name(name string) string {
 	el := strings.Split(name, separator)
 	if len(el) < 4 {
@@ -416,8 +417,8 @@ func Name(name string) string {
 	return el[1] + separator + el[2]
 }
 
-// Image returns the <image> from the well formed name. See Name.
-func Image(name string) string {
+// Container returns the <container> from the well formed name. See Name.
+func Container(name string) string {
 	el := strings.Split(name, separator)
 	if len(el) < 4 {
 		return ""

--- a/internal/provider/pod_test.go
+++ b/internal/provider/pod_test.go
@@ -3,9 +3,9 @@ package provider
 import "testing"
 
 func TestNameSplitting(t *testing.T) {
-	name := "systemk.default.openssh-server.openssh-server-image.service"
-	if x := Image(name); x != "openssh-server-image" {
-		t.Errorf("expected Image to be %s, got %s", "openssh-server-image", x)
+	name := "systemk.default.openssh-server.openssh-server-container.service"
+	if x := Container(name); x != "openssh-server-container" {
+		t.Errorf("expected Image to be %s, got %s", "openssh-server-container", x)
 	}
 	if x := Pod(name); x != "openssh-server" {
 		t.Errorf("expected Pod to be %s, got %s", "openssh-server", x)

--- a/internal/provider/unit.go
+++ b/internal/provider/unit.go
@@ -109,7 +109,7 @@ func (p *p) toContainers(stats map[string]*unit.State) ([]corev1.Container, []co
 		u, _ := unit.NewFile(s.UnitData)
 		container := v1.Container{
 			Name:      Name(k),
-			Image:     Image(k),
+			Image:     u.Contents[kubernetesSection]["Image"][0],
 			Command:   u.Contents["Service"]["ExecStart"],
 			Resources: v1.ResourceRequirements{
 				/*
@@ -147,8 +147,8 @@ func (p *p) toContainerStatuses(stats map[string]*unit.State) ([]corev1.Containe
 			LastTerminationState: p.containerState(s),
 			Ready:                true, // readiness probes on the container level??
 			RestartCount:         int32(restarts),
-			Image:                Image(k),
-			ImageID:              hash(Image(k)),
+			Image:                u.Contents[kubernetesSection]["Image"][0],
+			ImageID:              hash(u.Contents[kubernetesSection]["Image"][0]),
 			ContainerID:          "pid://" + p.unitManager.ServiceProperty(k, "MainPID"),
 		}
 		if u.Contents[kubernetesSection]["InitContainer"] != nil {

--- a/internal/provider/unit.go
+++ b/internal/provider/unit.go
@@ -108,8 +108,8 @@ func (p *p) toContainers(stats map[string]*unit.State) ([]corev1.Container, []co
 		s := stats[k]
 		u, _ := unit.NewFile(s.UnitData)
 		container := v1.Container{
-			Name:      Image(k),
-			Image:     Image(k), // We not saving the image anywhere, this assume container.Name == container.Image
+			Name:      Name(k),
+			Image:     Image(k),
 			Command:   u.Contents["Service"]["ExecStart"],
 			Resources: v1.ResourceRequirements{
 				/*

--- a/internal/testdata/provider/hello.units
+++ b/internal/testdata/provider/hello.units
@@ -25,3 +25,4 @@ Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 Namespace=default
 ClusterName=
 Id=aa-bb
+Image=bash

--- a/internal/testdata/provider/prometheus.units
+++ b/internal/testdata/provider/prometheus.units
@@ -27,3 +27,4 @@ Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 Namespace=default
 ClusterName=
 Id=aa-bb
+Image=prometheus

--- a/internal/testdata/provider/prometheus.yaml
+++ b/internal/testdata/provider/prometheus.yaml
@@ -10,7 +10,7 @@ spec:
   serviceAccountName: prometheus
   containers:
   - name: prometheus
-    image: deb://www.miek.nl/prometheus_2.23.0-0~20.040_amd64.deb
+    image: https://www.miek.nl/prometheus_2.23.0-0~20.040_amd64.deb
     args:
     - "--config.file=/etc/prometheus/prometheus.yml"
     - "--storage.tsdb.path=/tmp/prometheus"

--- a/internal/testdata/provider/uptimed.units
+++ b/internal/testdata/provider/uptimed.units
@@ -27,6 +27,7 @@ Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 Namespace=default
 ClusterName=
 Id=aa-bb
+Image=uptimed
 [Unit]
 Description=systemk
 Documentation=man:systemk(8)
@@ -58,3 +59,4 @@ Environment=SYSTEMK_NODE_EXTERNAL_IP=172.16.0.1
 Namespace=default
 ClusterName=
 Id=aa-bb
+Image=bash


### PR DESCRIPTION
This clears up the Image == Name confusion. Add some documentation to
the Container, Namespace, Pod and Image functions that makes clearer how they
are used.

The image name is now stored in the X-Kubernetes section of the unit

Closes: #42

Signed-off-by: Miek Gieben <miek@miek.nl>
