### PR TITLE
user mode: use /var/run/user/$UID for other dirs as well

### DIFF
--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -382,7 +382,7 @@ func (p *p) DeletePod(ctx context.Context, pod *corev1.Pod) error {
 	p.podResourceManager.Unwatch(pod)
 
 	// Clean-up volumes.
-	if err := cleanPodEphemeralVolumes(string(pod.UID)); err != nil {
+	if err := p.cleanPodEphemeralVolumes(string(pod.UID)); err != nil {
 		fnlog.Warn("failed to clean-up volumes: %s", err)
 	}
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -52,6 +52,7 @@ type p struct {
 	config      *Opts
 	pkgManager  ospkg.Manager
 	unitManager unit.Manager
+	runDir      string // writeable directory under /var/run for configmap/secrets/emptydir mounts
 
 	podResourceManager kubernetes.PodResourceManager
 	kubernetesURL      string // TODO(pires) pass this in Opts
@@ -70,8 +71,10 @@ var unitDir = defaultUnitDir
 // informerFactory is the basis for ConfigMap and Secret retrieval and event handling.
 func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceManager) (Provider, error) {
 	// If running in user-mode, set different folder for storing unit files.
+	runDir := "/var/run"
 	if config.UserMode {
 		unitDir = fmt.Sprintf("/var/run/user/%d/systemk", os.Geteuid())
+		runDir = fmt.Sprintf("/var/run/user/%d", os.Geteuid())
 	}
 	if err := os.MkdirAll(unitDir, 0750); err != nil {
 		return nil, err
@@ -84,6 +87,7 @@ func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceMan
 		unitManager:        unitManager,
 		config:             config,
 		podResourceManager: podWatcher,
+		runDir:             runDir,
 	}
 
 	systemID := system.ID()

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -24,6 +26,7 @@ func TestProviderPodSpecUnits(t *testing.T) {
 	p := new(p)
 	p.pkgManager = &ospkg.NoopManager{}
 	p.unitManager, _ = unit.NewMockManager()
+	p.runDir = fmt.Sprintf("/var/run/user/%d", os.Geteuid())
 	p.config = &Opts{
 		AllowedHostPaths: DefaultAllowedPaths,
 		NodeName:         "localhost",

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -2,9 +2,7 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"io/ioutil"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -26,7 +24,7 @@ func TestProviderPodSpecUnits(t *testing.T) {
 	p := new(p)
 	p.pkgManager = &ospkg.NoopManager{}
 	p.unitManager, _ = unit.NewMockManager()
-	p.runDir = fmt.Sprintf("/var/run/user/%d", os.Geteuid())
+	p.runDir = "/var/run"
 	p.config = &Opts{
 		AllowedHostPaths: DefaultAllowedPaths,
 		NodeName:         "localhost",


### PR DESCRIPTION
This moves the configmap/secrets/emptydir stuff under /var/run/user/$UID
when run with the -u flag.

A user mode ran systemk still needs CAP_CHOWN to the chown the dir to
the user of the pod - but we may be able to ignore that error.
Previously systemk would just not run any pods in usermode because it
can create any of the volumes for the pod.

Signed-off-by: Miek Gieben <miek@miek.nl>
