### PR TITLE
apt-get update is broken

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -19,7 +19,6 @@ jobs:
 
     - name: Install systemd lib dependencies
       run: |
-        sudo apt update
         sudo apt install libsystemd-dev
 
     - name: Get dependencies


### PR DESCRIPTION
Err:12 https://apt.postgresql.org/pub/repos/apt bionic-pgdg Release
  Certificate verification failed: The certificate is NOT trusted. The
  received OCSP status response is invalid.  Could not handshake: Error
  in the certificate verification. [IP: 72.32.157.246 443]

This stops the build and I can't release.

Signed-off-by: Miek Gieben <miek@miek.nl>
