### PR TITLE
Fix container name

### DIFF
--- a/internal/provider/unit.go
+++ b/internal/provider/unit.go
@@ -108,7 +108,7 @@ func (p *p) toContainers(stats map[string]*unit.State) ([]corev1.Container, []co
 		s := stats[k]
 		u, _ := unit.NewFile(s.UnitData)
 		container := v1.Container{
-			Name:      Name(k),
+			Name:      Container(k),
 			Image:     u.Contents[kubernetesSection]["Image"][0],
 			Command:   u.Contents["Service"]["ExecStart"],
 			Resources: v1.ResourceRequirements{
@@ -142,7 +142,7 @@ func (p *p) toContainerStatuses(stats map[string]*unit.State) ([]corev1.Containe
 		u, _ := unit.NewFile(s.UnitData)
 		restarts, _ := strconv.Atoi(p.unitManager.ServiceProperty(k, "NRestarts"))
 		status := v1.ContainerStatus{
-			Name:                 Name(k),
+			Name:                 Container(k),
 			State:                p.containerState(s),
 			LastTerminationState: p.containerState(s),
 			Ready:                true, // readiness probes on the container level??


### PR DESCRIPTION
The name of the container, must be the `Container` not `Name` as this
doubles the namespace in it leading to bugs where you can't find the
unit file you started.

Signed-off-by: Miek Gieben <miek@miek.nl>
