### PR TITLE
add map-root flag

### DIFF
--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -37,6 +37,7 @@ func installFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.StringVar(&c.ListenAddress, "addr", provider.DefaultListenAddr, "address to bind for serving requests from the Kubernetes API server")
 	flags.StringVar(&c.MetricsAddr, "metrics-addr", provider.DefaultMetricsAddr, "address to listen for metrics/stats requests")
 	flags.IntVar(&c.PodSyncWorkers, "pod-sync-workers", provider.DefaultPodSyncWorkers, `number of pod synchronization workers`)
+	flags.IntVar(&c.MapRoot, "map-root", 0, "map the root user to this UID")
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", provider.DefaultInformerResyncPeriod, "interval period for recurring listing of all Pods assigned to this Node")
 	flags.DurationVar(&c.StreamIdleTimeout, "stream-idle-timeout", provider.DefaultStreamIdleTimeout,
 		"maximum time a streaming connection can be idle before the connection is automatically closed")

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -37,7 +37,7 @@ func installFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.StringVar(&c.ListenAddress, "addr", provider.DefaultListenAddr, "address to bind for serving requests from the Kubernetes API server")
 	flags.StringVar(&c.MetricsAddr, "metrics-addr", provider.DefaultMetricsAddr, "address to listen for metrics/stats requests")
 	flags.IntVar(&c.PodSyncWorkers, "pod-sync-workers", provider.DefaultPodSyncWorkers, `number of pod synchronization workers`)
-	flags.IntVar(&c.MapRoot, "map-root", 0, "map the root user to this UID")
+	flags.IntVar(&c.OverrideRootUID, "override-root-uid", 0, "override the root user with this UID")
 	flags.DurationVar(&c.InformerResyncPeriod, "full-resync-period", provider.DefaultInformerResyncPeriod, "interval period for recurring listing of all Pods assigned to this Node")
 	flags.DurationVar(&c.StreamIdleTimeout, "stream-idle-timeout", provider.DefaultStreamIdleTimeout,
 		"maximum time a streaming connection can be idle before the connection is automatically closed")

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -103,6 +103,9 @@ type Opts struct {
 	// UserMode is whether to use the user's systemd or the system's.
 	UserMode bool
 
+	// MapRoot maps the root user to this UID (defaults to 0).
+	MapRoot int
+
 	// Version carries the systemk version.
 	Version string
 }

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -103,8 +103,8 @@ type Opts struct {
 	// UserMode is whether to use the user's systemd or the system's.
 	UserMode bool
 
-	// MapRoot maps the root user to this UID (defaults to 0).
-	MapRoot int
+	// OverrideRootUID maps the root user to this UID (defaults to 0).
+	OverrideRootUID int
 
 	// Version carries the systemk version.
 	Version string

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -17,6 +17,7 @@
 package provider
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -112,7 +113,7 @@ type Opts struct {
 
 // SetDefaultOpts sets default options for unset values of the passed in option struct.
 // Fields that are already set will not be modified.
-func SetDefaultOpts(opts *Opts) {
+func SetDefaultOpts(opts *Opts) error {
 	if len(opts.AllowedHostPaths) == 0 {
 		opts.AllowedHostPaths = DefaultAllowedPaths
 	}
@@ -164,6 +165,12 @@ func SetDefaultOpts(opts *Opts) {
 	if len(opts.AllowedHostPaths) == 0 {
 		opts.AllowedHostPaths = DefaultAllowedPaths
 	}
+
+	if opts.OverrideRootUID < 0 {
+		return fmt.Errorf("the value for --override-root-uid must be positive: %d", opts.OverrideRootUID)
+	}
+
+	return nil
 }
 
 // getEnvOrDefault returns environment variable value or if unset, a default value.

--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -76,7 +76,7 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		return err
 	}
 
-	uid, gid, err := uidGidFromSecurityContext(pod, p.config.MapRoot)
+	uid, gid, err := uidGidFromSecurityContext(pod, p.config.OverrideRootUID)
 	if err != nil {
 		return err
 	}

--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -76,7 +76,10 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		return err
 	}
 
-	uid, gid := uidGidFromSecurityContext(pod)
+	uid, gid, err := uidGidFromSecurityContext(pod, p.config.MapRoot)
+	if err != nil {
+		return err
+	}
 	tmp := []string{"/var", "/run"}
 
 	unitsToStart := []string{}

--- a/internal/provider/security_context_test.go
+++ b/internal/provider/security_context_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/virtual-kubelet/systemk/internal/kubernetes"
+)
+
+func TestUidGidFromSecurityContext(t *testing.T) {
+	yamlFile := "../testdata/uptimed-config.yaml"
+	pod, err := kubernetes.PodFromFile(yamlFile)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	uid, gid, err := uidGidFromSecurityContext(pod, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != "0" {
+		t.Errorf("expected uid to be %q, got %q", "0", uid)
+	}
+	if gid != "0" {
+		t.Errorf("expected uid to be %q, got %q", "0", gid)
+	}
+
+	// now map the uid
+	uid, gid, err = uidGidFromSecurityContext(pod, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != "1" {
+		t.Errorf("expected uid to be %q, got %q", "1", uid)
+	}
+	if gid != "1" {
+		t.Errorf("expected uid to be %q, got %q", "1", gid)
+	}
+}

--- a/internal/provider/volumes.go
+++ b/internal/provider/volumes.go
@@ -39,7 +39,7 @@ func (p *p) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 
 	vol := make(map[string]string)
 	id := string(pod.ObjectMeta.UID)
-	uid, gid, err := uidGidFromSecurityContext(pod, p.config.MapRoot)
+	uid, gid, err := uidGidFromSecurityContext(pod, p.config.OverrideRootUID)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/provider/volumes.go
+++ b/internal/provider/volumes.go
@@ -39,7 +39,10 @@ func (p *p) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 
 	vol := make(map[string]string)
 	id := string(pod.ObjectMeta.UID)
-	uid, gid := uidGidFromSecurityContext(pod)
+	uid, gid, err := uidGidFromSecurityContext(pod, p.config.MapRoot)
+	if err != nil {
+		return nil, err
+	}
 	for i, v := range pod.Spec.Volumes {
 		fnlog.Debugf("looking at volume %q#%d", v.Name, i)
 		switch {

--- a/internal/testdata/uptimed-config.yaml
+++ b/internal/testdata/uptimed-config.yaml
@@ -6,7 +6,7 @@ metadata:
     name: uptimed
 spec:
   securityContext:
-    runAsUser: 1
+    runAsUser: 0
   containers:
   - name: uptimed
     image: uptimed

--- a/main.go
+++ b/main.go
@@ -58,7 +58,9 @@ func main() {
 
 	// Default systemk provider configuration.
 	var opts provider.Opts
-	provider.SetDefaultOpts(&opts)
+	if err := provider.SetDefaultOpts(&opts); err != nil {
+		log.Fatal(err)
+	}
 	// The Kubernetes version systemk tracks.
 	// This is important because of Kubernetes version skew policy.
 	// See https://kubernetes.io/docs/setup/release/version-skew-policy/#kubelet
@@ -72,6 +74,5 @@ func main() {
 		log.Fatal(err)
 	}
 
-	log.Info("system exited gracefully")
-
+	log.Info("systemk exited gracefully")
 }


### PR DESCRIPTION
This maps the root user to another ID, meaning no pods will be run with
root perms. This is an alternative approach to the failed, run systemk
as a user.

Test the security context parsing and make it return an error as well.

Signed-off-by: Miek Gieben <miek@miek.nl>
