### PR TITLE
Remove user mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,6 @@ If the image name starts with a `/` it's assumed to be a path to a binary that e
 nothing is installed in that case. Basically this tells systemk that the image is not used. This can
 serve as documentation. It's likely command and/or args in the podspec will reference the same path.
 
-This mode helps in running systemk as a non-root user.
-
 ### Addresses
 
 Addresses are configured with one the systemk command line flags: `--node-ip` and

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -47,7 +47,6 @@ func installFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.IPVar(&c.NodeInternalIP, "internal-ip", net.IPv4zero, "IP address to advertise as Node InternalIP, 0.0.0.0 means auto-detect")
 	flags.IPVar(&c.NodeExternalIP, "external-ip", net.IPv4zero, "IP address to advertise as Node ExternalIP, 0.0.0.0 means auto-detect")
 	flags.StringSliceVarP(&c.AllowedHostPaths, "dir", "d", provider.DefaultAllowedPaths, "only allow mounts below these directories")
-	flags.BoolVarP(&c.UserMode, "user", "u", false, "rely on the user's systemd")
 	flags.BoolVarP(&c.DisableTaint, "disable-taint", "", false, "disable the node taint")
 
 	// Since klog is the logger implementation, install its flags.

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -100,9 +100,6 @@ type Opts struct {
 	// StreamCreationTimeout is the maximum time for streaming connection.
 	StreamCreationTimeout time.Duration
 
-	// UserMode is whether to use the user's systemd or the system's.
-	UserMode bool
-
 	// Version carries the systemk version.
 	Version string
 }

--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -173,18 +173,14 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		uf = uf.Insert("Service", "StandardOutput", "journal")
 		uf = uf.Insert("Service", "StandardError", "journal")
 
-		// If there is a securityContext we'll use that.
-		// But if in user-mode, we delete any user/group settings.
-		if p.config.UserMode {
-			uf = uf.Delete("Service", "User")
-			uf = uf.Delete("Service", "Group")
-		} else {
-			if uid != "" {
-				uf = uf.Overwrite("Service", "User", uid)
-			}
-			if gid != "" {
-				uf = uf.Overwrite("Service", "Group", gid)
-			}
+		// TODO(miek): double check when this is empty and close that loophole, i.e. a service file
+		// that allows running as root and no SecurityContext in the pod spec, this must the map-root
+		// flag into account as well.
+		if uid != "" {
+			uf = uf.Overwrite("Service", "User", uid)
+		}
+		if gid != "" {
+			uf = uf.Overwrite("Service", "Group", gid)
 		}
 
 		// Treat initContainer differently.

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -62,21 +61,13 @@ var _ Provider = (*p)(nil)
 
 const defaultUnitDir = "/var/run/systemk"
 
-// unitDir is where systemk stores the modified unit files.
-// Its value changes if systemk is running in user-mode.
-var unitDir = defaultUnitDir
-
 // New returns a new systemd provider.
 // informerFactory is the basis for ConfigMap and Secret retrieval and event handling.
 func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceManager) (Provider, error) {
-	// If running in user-mode, set different folder for storing unit files.
-	if config.UserMode {
-		unitDir = fmt.Sprintf("/var/run/user/%d/systemk", os.Geteuid())
-	}
-	if err := os.MkdirAll(unitDir, 0750); err != nil {
+	if err := os.MkdirAll(defaultUnitDir, 0750); err != nil {
 		return nil, err
 	}
-	unitManager, err := unit.NewManager(unitDir, config.UserMode)
+	unitManager, err := unit.NewManager(defaultUnitDir)
 	if err != nil {
 		return nil, err
 	}
@@ -91,10 +82,6 @@ func New(ctx context.Context, config *Opts, podWatcher kubernetes.PodResourceMan
 	case "debian", "ubuntu":
 		p.pkgManager = new(ospkg.DebianManager)
 
-		// Check if we're root and otherwise skip this step.
-		if os.Geteuid() != 0 {
-			break
-		}
 		// Just installed pre-requisites instead of pointing to the docs.
 		log.Infof("installing %s, to prevent installed daemons from starting", "policyrcd-script-zg2")
 		ok, err := p.pkgManager.Install("policyrcd-script-zg2", "")

--- a/internal/unit/manager.go
+++ b/internal/unit/manager.go
@@ -61,14 +61,8 @@ type manager struct {
 var _ Manager = (*manager)(nil)
 
 // NewManager returns an initialized dBus unit manager.
-func NewManager(uDir string, systemdUser bool) (Manager, error) {
-	var systemd *dbus.Conn
-	var err error
-	if systemdUser {
-		systemd, err = dbus.NewUserConnection()
-	} else {
-		systemd, err = dbus.New()
-	}
+func NewManager(uDir string) (Manager, error) {
+	systemd, err := dbus.New()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This removes the -u flag and assorted code, i.e. we will always use the
system's systemd (and run as root).

Left a TODO that I will shortly address to map to a non-root user (if
that flag is set) if the unit file says run as root and no security
context is provided in the prodspec.

Signed-off-by: Miek Gieben <miek@miek.nl>
