### PR TITLE
Remove tmp variable

### DIFF
--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -80,7 +80,7 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 	if err != nil {
 		return err
 	}
-	tmp := []string{"/var", "/run"}
+	tmpfs := strings.Join([]string{"/var", "/run"}, " ")
 
 	unitsToStart := []string{}
 	previousUnit := ""
@@ -212,7 +212,6 @@ func (p *p) CreatePod(ctx context.Context, pod *corev1.Pod) error {
 		uf = uf.Insert(kubernetesSection, "Id", id)
 		uf = uf.Insert(kubernetesSection, "Image", c.Image) // save (cleaned) image name here, we're not tracking this in the unit's name.
 
-		tmpfs := strings.Join(tmp, " ")
 		uf = uf.Insert("Service", "TemporaryFileSystem", tmpfs)
 		if len(rwpaths) > 0 {
 			paths := strings.Join(rwpaths, " ")


### PR DESCRIPTION
Remove the tmp variable and name it tmpfs to slightly better convey
how it will be used. Pull the join out of the loop also.

Signed-off-by: Miek Gieben <miek@miek.nl>
