### PR TITLE
Fix nodename setting

### DIFF
--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -30,7 +30,8 @@ import (
 // where we tie systemk logging to klogv2 (see the imports).
 var log = vklogv2.New(nil)
 
-func installFlags(flags *pflag.FlagSet, c *provider.Opts) {
+// InstallFlags sets up the flags for the command.
+func InstallFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.StringVar(&c.KubeConfigPath, "kubeconfig", "", "cluster client configuration")
 	flags.StringVar(&c.KubeClusterDomain, "cluster-domain", provider.DefaultKubeClusterDomain, "cluster domain")
 	flags.StringVar(&c.NodeName, "nodename", "", "value to be set as the Node name and label node.k8s.io/hostname")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,10 +49,6 @@ func NewRootCommand(ctx context.Context, name string, opts *provider.Opts) *cobr
 			return runRootCommand(ctx, opts)
 		},
 	}
-
-	// Setup flags.
-	installFlags(cmd.Flags(), opts)
-
 	return cmd
 }
 

--- a/main.go
+++ b/main.go
@@ -56,19 +56,21 @@ func main() {
 	// Setup VK logger.
 	vklog.L = vklogv2.New(map[string]interface{}{"source": "virtual-kubelet"})
 
+	opts := &provider.Opts{}
+	// Setup the root systemk CLI command.
+	rootCmd := cmd.NewRootCommand(ctx, filepath.Base(os.Args[0]), opts)
+	// Setup flags.
+	cmd.InstallFlags(rootCmd.Flags(), opts)
 	// Default systemk provider configuration.
-	var opts provider.Opts
-	if err := provider.SetDefaultOpts(&opts); err != nil {
+	if err := provider.SetDefaultOpts(opts); err != nil {
 		log.Fatal(err)
 	}
 	// The Kubernetes version systemk tracks.
 	// This is important because of Kubernetes version skew policy.
 	// See https://kubernetes.io/docs/setup/release/version-skew-policy/#kubelet
 	opts.Version = k8sVersion
-
-	// Setup the root systemk CLI command.
-	rootCmd := cmd.NewRootCommand(ctx, filepath.Base(os.Args[0]), &opts)
 	rootCmd.AddCommand(cmd.NewVersionCommand(buildVersion, buildTime))
+
 	// And fire up engines!
 	if err := rootCmd.Execute(); err != nil && errors.Cause(err) != context.Canceled {
 		log.Fatal(err)


### PR DESCRIPTION
The nodename is not working, the instalFlags would overwrite the
Opts with the default value in the flag string. So it would overwrite
it (in the case of nodename) with the empty value. This shows when
you don't have the HOSTNAME env var set (the case in my zsh setup)

Move this into the correct order, first set the flags, then set the
default options if the flag isn't set.

Signed-off-by: Miek Gieben <miek@miek.nl>
