### PR TITLE
Add --internal|--external-iface

### DIFF
--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -46,7 +46,9 @@ func installFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.StringVar(&c.ServerCertPath, "tls-cert", "", "path to the certificate to secure the kubelet API")
 	flags.StringVar(&c.ServerKeyPath, "tls-key", "", "path to the private key to sign the kubelet API")
 	flags.IPVar(&c.NodeInternalIP, "internal-ip", net.IPv4zero, "IP address to advertise as Node InternalIP, 0.0.0.0 means auto-detect")
+	flags.StringVar(&c.NodeInternalIface, "internal-iface", "", "IP address of this named interface to advertise as Node InternalIP, takes precedence over --internal-ip")
 	flags.IPVar(&c.NodeExternalIP, "external-ip", net.IPv4zero, "IP address to advertise as Node ExternalIP, 0.0.0.0 means auto-detect")
+	flags.StringVar(&c.NodeExternalIface, "external-iface", "", "IP address of this named interface to advertise as Node ExternalIP, takes precedence over --external-ip")
 	flags.StringSliceVarP(&c.AllowedHostPaths, "dir", "d", provider.DefaultAllowedPaths, "only allow mounts below these directories")
 	flags.BoolVarP(&c.DisableTaint, "disable-taint", "", false, "disable the node taint")
 

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -59,6 +59,12 @@ type Opts struct {
 	// NodeExternalIP is the desired Node external IP.
 	NodeExternalIP net.IP
 
+	// NodeInternalIface is interface's name whose address to use for Node internal IP.
+	NodeInternalIface string
+
+	// NodeExternalIface is the interface's name whose address to use for Node external IP.
+	NodeExternalIface string
+
 	// AllowedHostPaths is a list of host paths that are allowed to be mounted.
 	AllowedHostPaths []string
 

--- a/internal/system/system.go
+++ b/internal/system/system.go
@@ -157,3 +157,25 @@ func IPs() []net.IP {
 	}
 	return a
 }
+
+// IPFromInterface returns the first address found on the interface named name.
+func IPFromInterface(name string) (net.IP, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	if len(addrs) == 0 {
+		return nil, fmt.Errorf("failed to find addresses on interface %q", name)
+	}
+	switch v := addrs[0].(type) {
+	case *net.IPNet:
+		return v.IP, nil
+	case *net.IPAddr:
+		return v.IP, nil
+	}
+	return nil, fmt.Errorf("neither net or address found on interface %q", name)
+}

--- a/internal/system/system_test.go
+++ b/internal/system/system_test.go
@@ -69,3 +69,13 @@ func TestID(t *testing.T) {
 		}
 	}
 }
+
+func TestIPFromIface(t *testing.T) {
+	ip, err := IPFromInterface("lo")
+	if err != nil {
+		t.Error(err)
+	}
+	if !ip.IsLoopback() {
+		t.Errorf("Expected loopback IP on %q, got %s", "lo", ip)
+	}
+}


### PR DESCRIPTION
This takes the 1 address of the *interface* and uses this for internal
or external node IP. This saves a whole bunch of external parsing (ip
addr show | grep ...) to get this IP.

E.g. I've got another (more stable) address configured on lo:1, so just
specifying the iface would make the unit file more portible and less
fragile because no iface parsing scripts needs to be executed.

Signed-off-by: Miek Gieben <miek@miek.nl>
