### PR TITLE
ospkg: don't remove and then add 'https://'

### DIFF
--- a/internal/ospkg/debian.go
+++ b/internal/ospkg/debian.go
@@ -38,7 +38,7 @@ func (p *DebianManager) Install(pkg, version string) (bool, error) {
 	installCmd := new(exec.Cmd)
 	switch {
 	case strings.HasPrefix(pkg, "https://"):
-		pkgToInstall, err := fetch(pkg[6:], "")
+		pkgToInstall, err := fetch(pkg, "")
 		if err != nil {
 			return false, err
 		}

--- a/internal/ospkg/remote.go
+++ b/internal/ospkg/remote.go
@@ -18,7 +18,6 @@ func fetch(pkg, version string) (string, error) {
 	c := new(http.Client)
 	c.Timeout = 240 * time.Second
 
-	pkg = "https://" + pkg
 	log.Infof("fetching from %s", pkg)
 	resp, err := c.Get(pkg)
 	if err != nil {


### PR DESCRIPTION
This string was first removed and then added. Stop doing that.
Also matches the 'fetch' comment better.

Signed-off-by: Miek Gieben <miek@miek.nl>
