### PR TITLE
Let systemd create the mount path for us

### DIFF
--- a/internal/provider/volumes.go
+++ b/internal/provider/volumes.go
@@ -3,7 +3,6 @@ package provider
 import (
 	"encoding/base64"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -160,21 +159,6 @@ func (p *p) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 	}
 
 	return vol, nil
-}
-
-func isEmpty(name string) (bool, error) {
-	d, err := os.Open(name)
-	if err != nil {
-		return false, err
-	}
-	defer d.Close()
-
-	_, err = d.Readdirnames(1)
-	if err == io.EOF {
-		return true, nil
-	}
-
-	return false, err
 }
 
 // mkdirAllChown calls os.MkdirAll and chown to create path and set ownership.


### PR DESCRIPTION
I don't think there is a need to fiddle with this directory, also when
multiple pods run with different users we chown to diff. users, which
makes no sense.

Signed-off-by: Miek Gieben <miek@miek.nl>
