### PR TITLE
Match the complete prefix for the units

### DIFF
--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -428,7 +428,7 @@ func podToUnitName(pod *corev1.Pod, containerName string) string {
 }
 
 func unitPrefix(namespace, podName string) string {
-	return prefix + separator + namespace + separator + podName
+	return prefix + separator + namespace + separator + podName + separator // last seperator needs to be here, otherwise we will be prefix matching the wrong units.
 }
 
 // Name returns <namespace>.<podname> from a well formed name.


### PR DESCRIPTION
This was matching the prefix, which meant that uptime2 and uptime would
both be matched when we look for 'uptime'. Add the separator to the
matching so this doesn't happen.

Signed-off-by: Miek Gieben <miek@miek.nl>
