### PR TITLE
Remove retricting mount paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ Containers are also implemented.
 EmptyDir/configMap/hostPath and Secret are implemented, all, except hostPath, are backed by a
 bind-mount. The entire filesystem is made available, but read-only, paths declared as volumeMounts
 are read-only or read-write depending on settings. When configMaps and Secrets are mutated the new
-contents are updated on disk.
+contents are updated on disk. These directories are set up in
+`/var/run/{emptydirs, secrets, configmaps}`.
 
-Getting logs also works, but the UI for it could be better; this mostly due to TLS certificates not
-being generated.
+Retrieving pod logs also works, but setting up TLS is not automated.
 
 Has been tested on:
 

--- a/README.md
+++ b/README.md
@@ -149,11 +149,6 @@ The primary group will be found by systemk and both a `User` and `Group` will be
 unit file. The files created on disk for the configMap/secrets/emptyDir will be made of the same
 user/group.
 
-### Restricting mount points
-
-You can restrict the allowed mounts points for the pod's volumes. By default mounts under "/var" are
-allowed, but this can be changed via the `--dir` or `-d` flag.
-
 ### Running Without Root Permissions
 
 This is not possible, the tiniest thing we need is `BindPaths` which is not allowed when not running

--- a/cmd/flag.go
+++ b/cmd/flag.go
@@ -50,7 +50,6 @@ func InstallFlags(flags *pflag.FlagSet, c *provider.Opts) {
 	flags.StringVar(&c.NodeInternalIface, "internal-iface", "", "IP address of this named interface to advertise as Node InternalIP, takes precedence over --internal-ip")
 	flags.IPVar(&c.NodeExternalIP, "external-ip", net.IPv4zero, "IP address to advertise as Node ExternalIP, 0.0.0.0 means auto-detect")
 	flags.StringVar(&c.NodeExternalIface, "external-iface", "", "IP address of this named interface to advertise as Node ExternalIP, takes precedence over --external-ip")
-	flags.StringSliceVarP(&c.AllowedHostPaths, "dir", "d", provider.DefaultAllowedPaths, "only allow mounts below these directories")
 	flags.BoolVarP(&c.DisableTaint, "disable-taint", "", false, "disable the node taint")
 
 	// Since klog is the logger implementation, install its flags.

--- a/internal/provider/opts.go
+++ b/internal/provider/opts.go
@@ -38,7 +38,6 @@ var (
 	DefaultTaintValue            = "systemk"
 	DefaultStreamIdleTimeout     = 30 * time.Second
 	DefaultStreamCreationTimeout = 30 * time.Second
-	DefaultAllowedPaths          = []string{"/var"}
 )
 
 // Opts stores all the configuration options.
@@ -64,9 +63,6 @@ type Opts struct {
 
 	// NodeExternalIface is the interface's name whose address to use for Node external IP.
 	NodeExternalIface string
-
-	// AllowedHostPaths is a list of host paths that are allowed to be mounted.
-	AllowedHostPaths []string
 
 	// KubeConfigPath is the path to the Kubernetes client configuration.
 	KubeConfigPath string
@@ -117,10 +113,6 @@ type Opts struct {
 // SetDefaultOpts sets default options for unset values of the passed in option struct.
 // Fields that are already set will not be modified.
 func SetDefaultOpts(opts *Opts) error {
-	if len(opts.AllowedHostPaths) == 0 {
-		opts.AllowedHostPaths = DefaultAllowedPaths
-	}
-
 	if opts.NodeName == "" {
 		// If flag isn't set, try environment but fallback to systemd.
 		opts.NodeName = getEnvOrDefault("HOSTNAME", system.Hostname())
@@ -163,10 +155,6 @@ func SetDefaultOpts(opts *Opts) error {
 
 	if opts.StreamCreationTimeout == 0 {
 		opts.StreamCreationTimeout = DefaultStreamCreationTimeout
-	}
-
-	if len(opts.AllowedHostPaths) == 0 {
-		opts.AllowedHostPaths = DefaultAllowedPaths
 	}
 
 	if opts.OverrideRootUID < 0 {

--- a/internal/provider/provider_test.go
+++ b/internal/provider/provider_test.go
@@ -25,10 +25,9 @@ func TestProviderPodSpecUnits(t *testing.T) {
 	p.pkgManager = &ospkg.NoopManager{}
 	p.unitManager, _ = unit.NewMockManager()
 	p.config = &Opts{
-		AllowedHostPaths: DefaultAllowedPaths,
-		NodeName:         "localhost",
-		NodeInternalIP:   []byte{192, 168, 1, 1},
-		NodeExternalIP:   []byte{172, 16, 0, 1},
+		NodeName:       "localhost",
+		NodeInternalIP: []byte{192, 168, 1, 1},
+		NodeExternalIP: []byte{172, 16, 0, 1},
 	}
 
 	p.podResourceManager = kubernetes.NewPodResourceWatcher(informers.NewSharedInformerFactory(nil, 0))

--- a/internal/provider/volumes.go
+++ b/internal/provider/volumes.go
@@ -49,8 +49,8 @@ func (p *p) volumes(pod *corev1.Pod, which Volume) (map[string]string, error) {
 			if which != volumeAll {
 				continue
 			}
-			// should this be v.Path? We should make this writeable
-			// We should also check the allowed paths here. TODO(miek).
+
+			// v.Path should exist and be usuable by this pod. No checks are done here.
 			vol[v.Name] = ""
 
 		case v.EmptyDir != nil:

--- a/internal/provider/volumes_test.go
+++ b/internal/provider/volumes_test.go
@@ -23,35 +23,3 @@ func TestMkdirAll(t *testing.T) {
 		t.Fatal(err)
 	}
 }
-
-func TestIsBelowPath(t *testing.T) {
-	tests := []struct {
-		top   string
-		path  string
-		below bool
-	}{
-		{"/", "/tmp/x", true},
-		{"/", "/", false},
-		{"/tmp", "/", false},
-		{"/tmp/x", "/", false},
-	}
-	for i, tc := range tests {
-		ok := isBelowPath(tc.top, tc.path)
-		if ok != tc.below {
-			t.Errorf("test %d, expected %t, got %t", i, tc.below, ok)
-		}
-	}
-}
-func TestIsBelow(t *testing.T) {
-	if err := isBelow([]string{"/var", "/tmp"}, "/tmp/x"); err != nil {
-		t.Errorf("/tmp/x should be below /tmp")
-	}
-
-	if err := isBelow([]string{"/var", "/tmp"}, "/"); err == nil {
-		t.Errorf("/ should not be below /tmp or /var")
-	}
-
-	if err := isBelow([]string{"/var", "/tmp"}, "/var"); err == nil {
-		t.Errorf("/var should not be below /tmp or /var")
-	}
-}


### PR DESCRIPTION
Remove this feature. It was used to restrict where we (bind)mount, but
systemk controls that location, so no need to restrict.

Signed-off-by: Miek Gieben <miek@miek.nl>
