### PR TITLE
naming

### DIFF
--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -394,7 +394,7 @@ func podToUnitName(pod *corev1.Pod, containerName string) string {
 }
 
 func unitPrefix(namespace, podName string) string {
-	return prefix + separator + namespace + separator + podName + separator // last seperator needs to be here, otherwise we will be prefix matching the wrong units.
+	return prefix + separator + namespace + separator + podName
 }
 
 // Name returns <namespace>.<podname> from a well formed name.

--- a/internal/provider/pod.go
+++ b/internal/provider/pod.go
@@ -23,7 +23,8 @@ import (
 func (p *p) GetPod(ctx context.Context, namespace, name string) (*corev1.Pod, error) {
 	fnlog := log.WithField("podNamespace", namespace).WithField("podName", name)
 	fnlog.Debug("GetPod called")
-	stats, err := p.unitManager.States(unitPrefix(namespace, name))
+	unitprefix := unitPrefix(namespace, name) + separator // we need to closing dot here, otherwise will return update2, update3, when looking for update.
+	stats, err := p.unitManager.States(unitprefix)
 	if err != nil {
 		fnlog.Errorf("failed to retrieve systemd states respective to Pod: %s", err)
 		return nil, nil


### PR DESCRIPTION
- Revert "Match the complete prefix for the units (#112)"
- Really fix naming for units
